### PR TITLE
fix: CORS設定に本番環境URLを追加

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:3000"  # Next.jsが動いてるオリジン
+    origins "http://localhost:3000", "https://sodateru.vercel.app"
     resource "*",
       headers: :any,
       methods: %i[get post put patch delete options head],


### PR DESCRIPTION
## 概要
本番環境でフロントエンド（Vercel）からバックエンド（Render）への API通信を可能にするため、CORS設定にVercelの本番URLを追加しました。

## 問題
本番環境でフロントエンドからAPI呼び出し時に以下のCORSエラーが発生：
```
Access to fetch at 'https://sodateru-backend.onrender.com/up' from origin 'https://sodateru.vercel.app' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## 解決内容

### 変更ファイル
- `backend/config/initializers/cors.rb`

### 変更内容
```ruby
# Before
origins "http://localhost:3000"

# After  
origins "http://localhost:3000", "https://sodateru.vercel.app"
```

## 動作確認
本番環境での開発者ツールConsoleでAPI接続テストを実行：
```javascript
fetch('https://sodateru-backend.onrender.com/up')
```
### 動作結果
- [x] Status: 200
- [x] CORSエラーなし
- [x] Response length: 73
- [x] 正常にデータ受信

## 関連Issue
- #75
- #15

Closes #83 