### PR TITLE
feat: タイムライン投稿に日時表示追加・成長記録投稿のタイトル削除

### DIFF
--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -287,12 +287,9 @@ export default function GrowthRecordDetail({ id }: Props) {
             {posts.map((post) => (
               <div key={post.id} className="border-b border-gray-200 pb-4 last:border-b-0">
                 <div className="flex justify-between items-start mb-2">
-                  <div>
-                    <h3 className="font-medium text-gray-900">{post.title}</h3>
-                    <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
-                      {post.category.name}
-                    </span>
-                  </div>
+                  <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                    {post.category.name}
+                  </span>
                   <div className="text-sm text-gray-500">
                     {formatDateTime(post.created_at)}
                   </div>

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -304,25 +304,6 @@ export default function CreatePostModal({
               </div>
             )}
 
-            {/* タイトル（成長記録投稿の場合のみ表示） */}
-            {formData.post_type === 'growth_record_post' && (
-              <div>
-                <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
-                  タイトル <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  id="title"
-                  name="title"
-                  value={formData.title}
-                  onChange={handleInputChange}
-                  required
-                  maxLength={100}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
-                  placeholder="タイトルを入力してください"
-                />
-              </div>
-            )}
 
             {/* 内容 */}
             <div>

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -38,48 +38,66 @@ export default function TimelinePost({ post }: TimelinePostProps) {
     }
   }
 
+  const formatDateTime = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
   return (
     <div>
       {/* ヘッダー部分 */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center space-x-2">
-          <div className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center">
-            <span className="text-white font-medium text-sm">
-              {post.user.name.charAt(0)}
-            </span>
-          </div>
-          <span className="font-medium text-gray-900">{post.user.name}</span>
-        </div>
-        <div className="flex items-center space-x-2">
-          {/* 投稿タイプ表示 */}
+      <div className="mb-3">
+        {/* 1行目: ユーザー名（左）+ 日時・メニュー（右） */}
+        <div className="flex items-center justify-between mb-2">
           <div className="flex items-center space-x-2">
-            {post.post_type === 'growth_record_post' && post.growth_record ? (
-              <Link 
-                href={`/growth-records/${post.growth_record.id}`}
-                className="px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 hover:bg-green-200 transition-colors cursor-pointer"
-              >
-                🌱 成長記録
-              </Link>
-            ) : (
-              <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                post.post_type === 'growth_record_post' 
-                  ? 'bg-green-100 text-green-800' 
-                  : 'bg-blue-100 text-blue-800'
-              }`}>
-                {post.post_type === 'growth_record_post' ? '🌱 成長記録' : '💬 雑談'}
+            <div className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center">
+              <span className="text-white font-medium text-sm">
+                {post.user.name.charAt(0)}
               </span>
-            )}
-            {post.post_type === 'growth_record_post' && post.category && (
-              <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
-                {post.category.name}
-              </span>
-            )}
+            </div>
+            <span className="font-medium text-gray-900">{post.user.name}</span>
           </div>
-          <button className="text-gray-400">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-            </svg>
-          </button>
+          <div className="flex items-center space-x-2">
+            <span className="text-sm text-gray-500">
+              {formatDateTime(post.created_at)}
+            </span>
+            <button className="text-gray-400">
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        
+        {/* 2行目: 成長記録・カテゴリ（左寄せ） */}
+        <div className="flex items-center space-x-2">
+          {post.post_type === 'growth_record_post' && post.growth_record ? (
+            <Link 
+              href={`/growth-records/${post.growth_record.id}`}
+              className="px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 hover:bg-green-200 transition-colors cursor-pointer"
+            >
+              🌱 成長記録
+            </Link>
+          ) : (
+            <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+              post.post_type === 'growth_record_post' 
+                ? 'bg-green-100 text-green-800' 
+                : 'bg-blue-100 text-blue-800'
+            }`}>
+              {post.post_type === 'growth_record_post' ? '🌱 成長記録' : '💬 雑談'}
+            </span>
+          )}
+          {post.post_type === 'growth_record_post' && post.category && (
+            <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
+              {post.category.name}
+            </span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
### 概要
  タイムライン投稿に投稿日時を表示し、成長記録投稿からタイトル機能を削除してよりシン
  プルな投稿体験を実現

  ### 変更内容
  - タイムライン投稿に日時表示を追加（2025年7月20日 16:30形式）
  - タイムラインヘッダーを2行レイアウトに変更（重要度順配置）
  - 成長記録投稿作成時のタイトル入力欄を削除
  - 成長記録詳細ページの関連投稿一覧からタイトル表示を削除
  - カテゴリと日時による投稿識別に統一

  ### 動作確認
  - タイムライン投稿で日時が適切に表示される
  - 成長記録投稿作成時にタイトル入力が不要になる
  - 成長記録の関連投稿がカテゴリ・日時・内容で識別可能
  - デスクトップ・モバイル両方でレスポンシブ表示される

### 関連Issue
<!-- 関連するIssueがあれば -->
#117 
### CloseしたいIssue
Close #117 