### PR TITLE
refactor: アプリ全体を「おうちの畑」にリブランディング

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -8,8 +8,8 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "http://localhost:3000",
-            "https://sodateru.vercel.app",
-            /https:\/\/sodateru-.*\.vercel\.app/
+            "https://ouchi-no-hatake.vercel.app",
+            /https:\/\/ouchi-no-hatake-.*\.vercel\.app/
     resource "*",
       headers: :any,
       methods: %i[get post put patch delete options head],

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -1,13 +1,13 @@
 services:
   - type: web
-    name: sodateru-backend
+    name: ouchi-no-hatake-backend
     env: ruby
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec rails server -b 0.0.0.0 -p $PORT"
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: sodateru-db
+          name: ouchi-no-hatake-db
           property: connectionString
       - key: RAILS_MASTER_KEY
         sync: false
@@ -15,6 +15,6 @@ services:
         value: production
 
 databases:
-  - name: sodateru-db
-    databaseName: sodateru_production
-    user: sodateru_user
+  - name: ouchi-no-hatake-db
+    databaseName: ouchi_no_hatake_production
+    user: ouchi_no_hatake_user

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 // API設定
 export const API_BASE_URL = process.env.NODE_ENV === 'production' 
-  ? 'https://sodateru-backend.onrender.com'
+  ? 'https://ouchi-no-hatake.onrender.com'
   : 'http://localhost:3001'
 
 // API呼び出し用のヘルパー関数


### PR DESCRIPTION
  ### 概要
  サービス全体を「sodateru」から「おうちの畑（ouchi-no-hatake）」にリブランディングしました。

  ### 変更内容
  #### インフラ・サービス名変更
  - RenderサービスとDB名を「ouchi-no-hatake」系に変更
  - Vercelプロジェクトとドメインをouchi-no-hatake.vercel.appに変更

  #### コード設定更新
  - フロントエンドAPI接続先を新しいRender URL（`ouchi-no-hatake.onrender.com`）に更新
  - バックエンドCORS設定を新しいVercel URL（`ouchi-no-hatake.vercel.app`）に更新
  - render.yamlの全サービス名・DB名を新しい名前に統一

  #### 投稿機能修正
  - Postモデルからtitleフィールドのバリデーション削除
  - titleカラムにデフォルト値設定のマイグレーション追加
  - タイムラインで投稿0件時も投稿ボタンが表示されるよう修正

  ### デプロイ先
  - フロントエンド: https://ouchi-no-hatake.vercel.app
  - バックエンド: https://ouchi-no-hatake.onrender.com