### PR TITLE
fix: 未実装ページへのリンクを無効化してレビュー準備

### DIFF
--- a/frontend/src/components/layout/AuthenticatedFooter.tsx
+++ b/frontend/src/components/layout/AuthenticatedFooter.tsx
@@ -23,20 +23,20 @@ export default function AuthenticatedFooter() {
           </Link>
           
           {/* 育て方指南 */}
-          <Link href="/guides" className="flex flex-col items-center space-y-1">
+          <button disabled className="flex flex-col items-center space-y-1 opacity-50 cursor-not-allowed">
             <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
             </svg>
             <span className="text-xs">育て方指南</span>
-          </Link>
+          </button>
           
           {/* マイページ */}
-          <Link href="/mypage" className="flex flex-col items-center space-y-1">
+          <button disabled className="flex flex-col items-center space-y-1 opacity-50 cursor-not-allowed">
             <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clipRule="evenodd" />
             </svg>
             <span className="text-xs">マイページ</span>
-          </Link>
+          </button>
         </div>
         </nav>
       </div>

--- a/frontend/src/components/layout/HamburgerMenu.tsx
+++ b/frontend/src/components/layout/HamburgerMenu.tsx
@@ -91,42 +91,39 @@ export default function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
         {/* メニューアイテム */}
         <div className="py-2">
           {/* アカウント設定 */}
-          <a
-            href="/account"
-            className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100"
-            onClick={onClose}
+          <button
+            disabled
+            className="flex items-center px-4 py-3 text-gray-400 cursor-not-allowed w-full text-left"
           >
             <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>
-            アカウント設定
-          </a>
+            アカウント設定（準備中）
+          </button>
 
           {/* 通知設定 */}
-          <a
-            href="/notifications"
-            className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100"
-            onClick={onClose}
+          <button
+            disabled
+            className="flex items-center px-4 py-3 text-gray-400 cursor-not-allowed w-full text-left"
           >
             <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-3.12-3.12A3.945 3.945 0 0116 11.5a4 4 0 10-7.56 1.38L15 17z" />
             </svg>
-            通知設定
-          </a>
+            通知設定（準備中）
+          </button>
 
           <hr className="my-2" />
 
           {/* ヘルプ・サポート */}
-          <a
-            href="/help"
-            className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100"
-            onClick={onClose}
+          <button
+            disabled
+            className="flex items-center px-4 py-3 text-gray-400 cursor-not-allowed w-full text-left"
           >
             <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            ヘルプ・サポート
-          </a>
+            ヘルプ・サポート（準備中）
+          </button>
 
           {/* お問い合わせ */}
           <a
@@ -144,7 +141,7 @@ export default function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
 
           {/* 利用規約 */}
           <a
-            href="/terms"
+            href="/terms-of-service"
             className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100"
             onClick={onClose}
           >
@@ -156,7 +153,7 @@ export default function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
 
           {/* プライバシーポリシー */}
           <a
-            href="/privacy"
+            href="/privacy-policy"
             className="flex items-center px-4 py-3 text-gray-700 hover:bg-gray-100"
             onClick={onClose}
           >


### PR DESCRIPTION
### 概要
  レビュー前の仕上げとして、未実装ページへのリンクを無効化し、404エラーを防止しました。

  ### 変更内容
  #### ハンバーガーメニュー
  - アカウント設定、通知設定、ヘルプ・サポートのリンクを無効化ボタンに変更
  - 「（準備中）」表示を追加
  - 利用規約・プライバシーポリシーのリンクパスを正しいパスに修正

  #### フッターナビゲーション
  - 育て方指南、マイページのリンクを無効化ボタンに変更
  - 半透明表示で未実装状態を視覚的に表現

  ### 修正した問題
  - 未実装ページへのリンククリック時の404エラー
  - レビュー時のナビゲーション体験の向上