### PR TITLE
feat: 成長記録とタイムラインのUI統一とナビゲーション改善

### DIFF
--- a/frontend/src/app/growth-records/page.tsx
+++ b/frontend/src/app/growth-records/page.tsx
@@ -30,8 +30,8 @@ export default function GrowthRecordsPage() {
   }
 
   return (
-    <div className="flex justify-center">
-      <div className="w-full max-w-2xl min-w-80 px-4 py-6">
+    <div className="flex justify-center" style={{ minWidth: '360px' }}>
+      <div className="w-full max-w-2xl px-4 py-6" style={{ minWidth: '360px' }}>
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 mb-2">成長記録</h1>
         <p className="text-gray-600">あなたの成長記録一覧</p>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body className="min-h-screen flex flex-col">
+      <body className="min-h-screen flex flex-col" style={{ minWidth: '360px' }}>
         <FlashProvider>
           <AuthProvider>
             <LayoutWrapper>

--- a/frontend/src/components/growth-records/GrowthRecordCard.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordCard.tsx
@@ -75,7 +75,7 @@ export default function GrowthRecordCard({ record, onUpdate }: Props) {
 
   return (
     <div 
-      className="bg-white rounded-lg shadow-md hover:shadow-lg border border-gray-200 transition-all duration-200 relative"
+      className="bg-white rounded-lg shadow-md hover:shadow-lg hover:-translate-y-1 hover:scale-[1.02] border border-gray-200 transition-all duration-200 relative"
       style={{ 
         zIndex: showMenu ? 9999 : 'auto'
       }}

--- a/frontend/src/components/growth-records/GrowthRecordCard.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordCard.tsx
@@ -74,61 +74,79 @@ export default function GrowthRecordCard({ record, onUpdate }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow">
+    <div 
+      className="bg-white rounded-lg shadow-md hover:shadow-lg border border-gray-200 transition-all duration-200 relative"
+      style={{ 
+        zIndex: showMenu ? 9999 : 'auto'
+      }}
+    >
+      {/* 背景リンク */}
+      {!showMenu && !isEditModalOpen && !isDeleteDialogOpen && (
+        <Link 
+          href={`/growth-records/${record.id}`} 
+          className="absolute inset-0 z-0 rounded-lg"
+        />
+      )}
       {/* モバイル表示 */}
-      <div className="md:hidden">
-        <Link href={`/growth-records/${record.id}`} className="block p-4">
+      <div className="md:hidden relative z-10 pointer-events-none">
+        <div className="p-4">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center space-x-3">
-              <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
-                <span className="text-2xl">🌱</span>
+              <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center pointer-events-auto">
+                <span className="text-2xl pointer-events-none">🌱</span>
               </div>
               <div>
                 <h3 className="font-semibold text-gray-900">{record.plant.name}</h3>
                 <p className="text-sm text-gray-600">{record.record_name}</p>
               </div>
             </div>
-            <div className="relative">
+            <div className="relative pointer-events-auto" style={{ zIndex: 100 }}>
               <button
-                onClick={(e) => {
-                  e.preventDefault()
-                  setShowMenu(!showMenu)
-                }}
-                className="p-2 text-gray-400 hover:text-gray-600"
+                onClick={() => setShowMenu(!showMenu)}
+                className="p-2 text-gray-400 hover:text-gray-600 cursor-pointer"
               >
                 <span className="text-lg">⋯</span>
               </button>
               {showMenu && (
-                <div className="absolute right-0 mt-2 w-32 bg-white rounded-lg shadow-lg border border-gray-200 z-10">
-                  <Link href={`/growth-records/${record.id}`} className="w-full px-4 py-2 text-left text-sm text-blue-600 hover:bg-gray-50 block">
-                    詳細
-                  </Link>
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      setShowMenu(false)
-                      setIsEditModalOpen(true)
-                    }}
-                    className="w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-gray-50"
-                  >
-                    編集
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      setShowMenu(false)
-                      setIsDeleteDialogOpen(true)
-                    }}
-                    className="w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-gray-50"
-                  >
-                    削除
-                  </button>
-                </div>
+                <>
+                  <div 
+                    className="fixed inset-0" 
+                    style={{ zIndex: 999 }}
+                    onClick={() => setShowMenu(false)}
+                  />
+                  <div className="absolute right-0 mt-2 w-32 bg-white rounded-lg shadow-lg border border-gray-200" style={{ zIndex: 1000 }}>
+                    <Link href={`/growth-records/${record.id}`} className="w-full px-4 py-2 text-left text-sm text-blue-600 hover:bg-gray-50 block">
+                      詳細
+                    </Link>
+                    <button
+                      onClick={() => {
+                        setShowMenu(false)
+                        setIsEditModalOpen(true)
+                      }}
+                      className="w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-gray-50"
+                    >
+                      編集
+                    </button>
+                    <button
+                      onClick={() => {
+                        setShowMenu(false)
+                        setIsDeleteDialogOpen(true)
+                      }}
+                      className="w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-gray-50"
+                    >
+                      削除
+                    </button>
+                  </div>
+                </>
               )}
             </div>
           </div>
           <div className="flex items-center justify-between text-sm text-gray-600">
-            <div>
+            <div 
+              className="pointer-events-auto cursor-default relative" 
+              style={{ zIndex: 10 }}
+              onClick={(e) => e.preventDefault()}
+            >
               <span className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(record.status)}`}>
                 {getStatusText(record.status)}
               </span>
@@ -137,53 +155,60 @@ export default function GrowthRecordCard({ record, onUpdate }: Props) {
               {record.started_on ? formatDate(record.started_on) : '---.--.-'} 〜 {record.ended_on ? formatDate(record.ended_on) : '---.--.-'}
             </div>
           </div>
-        </Link>
+        </div>
       </div>
 
       {/* デスクトップ表示 */}
-      <div className="hidden md:block">
-        <div className="py-3 px-4 hover:bg-gray-50 transition-colors">
+      <div className="hidden md:block relative z-10 pointer-events-none">
+        <div className="py-3 px-4">
           <div className="flex items-center space-x-4">
             {/* サムネイル用スペース */}
-            <div className="w-20 h-20 min-h-20 aspect-square bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
-              <span className="text-2xl">🌱</span>
+            <div className="w-20 h-20 min-h-20 aspect-square bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0 pointer-events-auto">
+              <span className="text-2xl pointer-events-none">🌱</span>
             </div>
             
             {/* メイン情報 */}
             <div className="flex-1 min-w-0">
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <Link href={`/growth-records/${record.id}`} className="font-semibold text-gray-900 text-lg truncate">
+                  <div className="font-semibold text-gray-900 text-lg truncate">
                     {record.plant.name}
                     {record.record_name && ` - ${record.record_name}`}
-                  </Link>
-                  <div className="flex items-center space-x-2 ml-4">
-                    <span className="inline-block px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-medium">
-                      {record.location}
-                    </span>
-                    <span className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(record.status)}`}>
-                      {getStatusText(record.status)}
-                    </span>
-                    <div className="relative">
+                  </div>
+                  <div className="flex items-center space-x-2 ml-4" style={{ position: 'relative', zIndex: 10 }}>
+                    <div 
+                      className="pointer-events-auto cursor-default"
+                      onClick={(e) => e.preventDefault()}
+                    >
+                      <span className="inline-block px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-medium">
+                        {record.location}
+                      </span>
+                    </div>
+                    <div 
+                      className="pointer-events-auto cursor-default"
+                      onClick={(e) => e.preventDefault()}
+                    >
+                      <span className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(record.status)}`}>
+                        {getStatusText(record.status)}
+                      </span>
+                    </div>
+                    <div className="relative pointer-events-auto" style={{ zIndex: 100 }}>
                       <button
-                        onClick={(e) => {
-                          e.preventDefault()
-                          setShowMenu(!showMenu)
-                        }}
-                        className="px-2 py-1 text-gray-400 hover:text-gray-600"
+                        onClick={() => setShowMenu(!showMenu)}
+                        className="px-2 py-1 text-gray-400 hover:text-gray-600 cursor-pointer"
                       >
                         <span className="text-2xl">⋯</span>
                       </button>
                       {showMenu && (
                         <>
                           <div 
-                            className="fixed inset-0 z-10" 
+                            className="fixed inset-0" 
+                            style={{ zIndex: 999 }}
                             onClick={() => setShowMenu(false)}
                           />
-                          <div className="absolute right-0 mt-2 w-32 bg-white rounded-lg shadow-lg border border-gray-200 z-20">
+                          <div className="absolute right-0 mt-2 w-32 bg-white rounded-lg shadow-lg border border-gray-200" style={{ zIndex: 1000 }}>
                             <button
-                              onClick={(e) => {
-                                e.preventDefault()
+                              onClick={() => {
                                 setShowMenu(false)
                                 setIsEditModalOpen(true)
                               }}
@@ -192,8 +217,7 @@ export default function GrowthRecordCard({ record, onUpdate }: Props) {
                               編集
                             </button>
                             <button
-                              onClick={(e) => {
-                                e.preventDefault()
+                              onClick={() => {
                                 setShowMenu(false)
                                 setIsDeleteDialogOpen(true)
                               }}
@@ -207,11 +231,9 @@ export default function GrowthRecordCard({ record, onUpdate }: Props) {
                     </div>
                   </div>
                 </div>
-                <Link href={`/growth-records/${record.id}`} className="block">
-                  <div className="text-sm text-gray-600">
-                    <div>栽培期間： {record.started_on ? formatDate(record.started_on) : '---.--.-'} 〜 {record.ended_on ? formatDate(record.ended_on) : '---.--.-'}</div>
-                  </div>
-                </Link>
+                <div className="text-sm text-gray-600">
+                  <div>栽培期間： {record.started_on ? formatDate(record.started_on) : '---.--.-'} 〜 {record.ended_on ? formatDate(record.ended_on) : '---.--.-'}</div>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -179,7 +179,7 @@ export default function GrowthRecordDetail({ id }: Props) {
             onClick={() => router.push('/growth-records')}
             className="text-blue-600 hover:text-blue-800"
           >
-            一覧に戻る
+            {'< '}成長記録一覧に戻る
           </button>
         </div>
       </div>
@@ -202,7 +202,7 @@ export default function GrowthRecordDetail({ id }: Props) {
           onClick={() => router.push(user && user.id === growthRecord.user.id ? '/growth-records' : '/')}
           className="text-blue-600 hover:text-blue-800 flex items-center"
         >
-          {user && user.id === growthRecord.user.id ? '一覧に戻る' : 'タイムラインに戻る'}
+          {'< '}{user && user.id === growthRecord.user.id ? '成長記録一覧に戻る' : 'タイムラインに戻る'}
         </button>
       </div>
 

--- a/frontend/src/components/growth-records/GrowthRecordList.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordList.tsx
@@ -122,7 +122,7 @@ export default function GrowthRecordList() {
   }
 
   return (
-    <div className="space-y-1">
+    <div style={{ minWidth: '360px' }}>
       {/* 記録を始めるボタン */}
       <div className="flex justify-center mb-6">
         <button
@@ -144,6 +144,7 @@ export default function GrowthRecordList() {
             <div
               key={record.id}
               ref={index === growthRecords.length - 1 ? lastRecordElementRef : undefined}
+              className="mb-4"
             >
               <GrowthRecordCard record={record} onUpdate={() => fetchGrowthRecords()} />
             </div>

--- a/frontend/src/components/layout/LayoutWrapper.tsx
+++ b/frontend/src/components/layout/LayoutWrapper.tsx
@@ -46,7 +46,7 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
     return (
       <>
         <AuthenticatedHeader />
-        <main className="flex-1 pt-20 pb-20">
+        <main className="flex-1 pt-20 pb-20" style={{ minWidth: '360px' }}>
           {children}
         </main>
         <AuthenticatedFooter />

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -146,7 +146,7 @@ export default function Timeline() {
               <div
                 key={post.id}
                 ref={index === posts.length - 1 ? lastPostElementRef : undefined}
-                className="hover:bg-white/20 hover:shadow-sm transition-all duration-200 px-4 py-4 border-b border-gray-300/60"
+                className="bg-white rounded-lg shadow-md hover:shadow-lg hover:-translate-y-1 hover:scale-[1.02] border border-gray-200 transition-all duration-200 px-4 py-4 mb-4"
               >
                 <TimelinePost post={post} />
               </div>


### PR DESCRIPTION
  ### 概要
  成長記録ページとタイムラインページのカードデザインを統一し、ユーザビリティを向上させました。また、成長記録カードのリンク動作とナビゲーション表示を改善しました。

  ### 変更内容
  - 成長記録カードにタイムラインと同じホバーエフェクト（hover:-translate-y-1, hover:scale-[1.02]）を追加
  - タイムラインカードを独立したカードデザインに変更（shadow-md → hover:shadow-lg）
  - 成長記録カードの栽培場所・ステータスバッジがクリックできないよう修正
  - 成長記録カード全体を背景リンクとして実装し、メニュー表示時は無効化
  - 成長記録詳細ページの戻るリンクを「< 成長記録一覧に戻る」に改善
  - 最小幅（360px）を設定してモバイル端末での表示を改善
  - カード間のマージンを統一（mb-4）