### PR TITLE
feat: JWT期限切れ自動検知とAPIフック統一化による認証システム強化

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from '@/contexts/AuthContext'
 import { FlashProvider } from '@/contexts/FlashContext'
 import LayoutWrapper from '@/components/layout/LayoutWrapper'
 import FlashMessages from '@/components/ui/FlashMessages'
+import AutoLogoutModalContainer from '@/components/ui/AutoLogoutModalContainer'
 
 export const metadata = {
   title: 'おうちの畑',
@@ -19,6 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               {children}
             </LayoutWrapper>
             <FlashMessages />
+            <AutoLogoutModalContainer />
           </AuthProvider>
         </FlashProvider>
       </body>

--- a/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
+++ b/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
@@ -43,6 +43,18 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
     status: 'planning' as 'planning' | 'growing' | 'completed' | 'failed'
   })
 
+  const fetchPlants = useCallback(async () => {
+    try {
+      const data = await publicCall('/api/v1/plants')
+      
+      if (data) {
+        setPlants(data.plants)
+      }
+    } catch (err) {
+      console.error('Error fetching plants:', err)
+    }
+  }, [publicCall])
+
   // 植物一覧取得と編集データ設定
   useEffect(() => {
     if (isOpen) {
@@ -61,18 +73,6 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
       }
     }
   }, [isOpen, editData, fetchPlants])
-
-  const fetchPlants = useCallback(async () => {
-    try {
-      const data = await publicCall('/api/v1/plants')
-      
-      if (data) {
-        setPlants(data.plants)
-      }
-    } catch (err) {
-      console.error('Error fetching plants:', err)
-    }
-  }, [publicCall])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
+++ b/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, editData }: Props) {
-  const { } = useAuth()
+  const { checkTokenValidity } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
   const { publicCall } = usePublicApi()
   const [plants, setPlants] = useState<Plant[]>([])
@@ -77,6 +77,11 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     clearError()
+
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
 
     try {
       const isEditMode = !!editData

--- a/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
+++ b/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
-import { API_BASE_URL } from '@/lib/api'
+import { useApi, usePublicApi } from '@/hooks/useApi'
 
 interface Plant {
   id: number
@@ -28,10 +28,10 @@ interface Props {
 }
 
 export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, editData }: Props) {
-  const { token } = useAuth()
+  const { user } = useAuth()
+  const { authenticatedCall, loading, error, clearError } = useApi()
+  const { publicCall } = usePublicApi()
   const [plants, setPlants] = useState<Plant[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   // フォーム状態
   const [formData, setFormData] = useState({
@@ -64,72 +64,55 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
 
   const fetchPlants = async () => {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/plants`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (!response.ok) {
-        throw new Error('植物一覧の取得に失敗しました')
+      const data = await publicCall('/api/v1/plants')
+      
+      if (data) {
+        setPlants(data.plants)
       }
-
-      const data = await response.json()
-      setPlants(data.plants)
     } catch (err) {
       console.error('Error fetching plants:', err)
-      setError('植物一覧の取得に失敗しました')
     }
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setLoading(true)
-    setError(null)
+    clearError()
 
     try {
       const isEditMode = !!editData
-      const url = isEditMode 
-        ? `${API_BASE_URL}/api/v1/growth_records/${editData.id}`
-        : `${API_BASE_URL}/api/v1/growth_records`
+      const endpoint = isEditMode 
+        ? `/api/v1/growth_records/${editData.id}`
+        : '/api/v1/growth_records'
       
       const method = isEditMode ? 'PUT' : 'POST'
 
-      const response = await fetch(url, {
+      const data = await authenticatedCall(endpoint, {
         method: method,
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           growth_record: formData
         })
       })
 
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || `成長記録の${isEditMode ? '更新' : '作成'}に失敗しました`)
+      if (data) {
+        // 成功時
+        onSuccess()
+        onClose()
+        
+        // フォームリセット
+        setFormData({
+          plant_id: '',
+          record_name: '',
+          location: '',
+          started_on: '',
+          ended_on: '',
+          status: 'planning'
+        })
       }
-
-      // 成功時
-      onSuccess()
-      onClose()
-      
-      // フォームリセット
-      setFormData({
-        plant_id: '',
-        record_name: '',
-        location: '',
-        started_on: '',
-        ended_on: '',
-        status: 'planning'
-      })
     } catch (err) {
       console.error(`Error ${editData ? 'updating' : 'creating'} growth record:`, err)
-      setError(err instanceof Error ? err.message : `成長記録の${editData ? '更新' : '作成'}に失敗しました`)
-    } finally {
-      setLoading(false)
     }
   }
 
@@ -143,7 +126,7 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
 
   const handleClose = () => {
     onClose()
-    setError(null)
+    clearError()
     setFormData({
       plant_id: '',
       record_name: '',

--- a/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
+++ b/frontend/src/components/growth-records/CreateGrowthRecordModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useApi, usePublicApi } from '@/hooks/useApi'
 
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, editData }: Props) {
-  const { user } = useAuth()
+  const { } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
   const { publicCall } = usePublicApi()
   const [plants, setPlants] = useState<Plant[]>([])
@@ -60,9 +60,9 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
         })
       }
     }
-  }, [isOpen, editData])
+  }, [isOpen, editData, fetchPlants])
 
-  const fetchPlants = async () => {
+  const fetchPlants = useCallback(async () => {
     try {
       const data = await publicCall('/api/v1/plants')
       
@@ -72,7 +72,7 @@ export default function CreateGrowthRecordModal({ isOpen, onClose, onSuccess, ed
     } catch (err) {
       console.error('Error fetching plants:', err)
     }
-  }
+  }, [publicCall])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
@@ -16,11 +16,16 @@ interface Props {
 }
 
 export default function DeleteConfirmDialog({ isOpen, onClose, onSuccess, growthRecord }: Props) {
-  const { } = useAuth()
+  const { checkTokenValidity } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
 
   const handleDelete = async () => {
     clearError()
+
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
 
     try {
       const data = await authenticatedCall(`/api/v1/growth_records/${growthRecord.id}`, {

--- a/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
@@ -16,33 +16,30 @@ interface Props {
 }
 
 export default function DeleteConfirmDialog({ isOpen, onClose, onSuccess, growthRecord }: Props) {
-  const { checkTokenValidity } = useAuth()
+  const { executeProtectedAsync } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
 
   const handleDelete = async () => {
     clearError()
 
-    // JWT有効性を事前チェック
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
+    await executeProtectedAsync(async () => {
+      try {
+        const data = await authenticatedCall(`/api/v1/growth_records/${growthRecord.id}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
 
-    try {
-      const data = await authenticatedCall(`/api/v1/growth_records/${growthRecord.id}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
+        if (data !== null) {
+          // 成功時
+          onSuccess()
+          onClose()
         }
-      })
-
-      if (data !== null) {
-        // 成功時
-        onSuccess()
-        onClose()
+      } catch (err) {
+        console.error('Error deleting growth record:', err)
       }
-    } catch (err) {
-      console.error('Error deleting growth record:', err)
-    }
+    })
   }
 
   const handleClose = () => {

--- a/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import React from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useApi } from '@/hooks/useApi'
 
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export default function DeleteConfirmDialog({ isOpen, onClose, onSuccess, growthRecord }: Props) {
-  const { user } = useAuth()
+  const { } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
 
   const handleDelete = async () => {

--- a/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/growth-records/DeleteConfirmDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
-import { API_BASE_URL } from '@/lib/api'
+import { useApi } from '@/hooks/useApi'
 
 interface Props {
   isOpen: boolean
@@ -16,42 +16,33 @@ interface Props {
 }
 
 export default function DeleteConfirmDialog({ isOpen, onClose, onSuccess, growthRecord }: Props) {
-  const { token } = useAuth()
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
+  const { authenticatedCall, loading, error, clearError } = useApi()
 
   const handleDelete = async () => {
-    setLoading(true)
-    setError(null)
+    clearError()
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/growth_records/${growthRecord.id}`, {
+      const data = await authenticatedCall(`/api/v1/growth_records/${growthRecord.id}`, {
         method: 'DELETE',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         }
       })
 
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || '成長記録の削除に失敗しました')
+      if (data !== null) {
+        // 成功時
+        onSuccess()
+        onClose()
       }
-
-      // 成功時
-      onSuccess()
-      onClose()
     } catch (err) {
       console.error('Error deleting growth record:', err)
-      setError(err instanceof Error ? err.message : '成長記録の削除に失敗しました')
-    } finally {
-      setLoading(false)
     }
   }
 
   const handleClose = () => {
     onClose()
-    setError(null)
+    clearError()
   }
 
   if (!isOpen) return null

--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -45,7 +45,7 @@ interface Props {
 }
 
 export default function GrowthRecordDetail({ id }: Props) {
-  const { user, checkTokenValidity } = useAuth()
+  const { user, executeProtected } = useAuth()
   const { authenticatedCall, loading, error } = useApi()
   const router = useRouter()
   const [growthRecord, setGrowthRecord] = useState<GrowthRecord | null>(null)
@@ -118,26 +118,22 @@ export default function GrowthRecordDetail({ id }: Props) {
     }
   }
 
-  // JWT有効性チェック付きボタンハンドラー
   const handleEditButtonClick = () => {
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
-    setIsEditModalOpen(true)
+    executeProtected(() => {
+      setIsEditModalOpen(true)
+    })
   }
 
   const handleDeleteButtonClick = () => {
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
-    setIsDeleteDialogOpen(true)
+    executeProtected(() => {
+      setIsDeleteDialogOpen(true)
+    })
   }
 
   const handleCreatePostButtonClick = () => {
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
-    setIsCreatePostModalOpen(true)
+    executeProtected(() => {
+      setIsCreatePostModalOpen(true)
+    })
   }
 
   const formatDate = (dateString: string) => {

--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -45,7 +45,7 @@ interface Props {
 }
 
 export default function GrowthRecordDetail({ id }: Props) {
-  const { user } = useAuth()
+  const { user, checkTokenValidity } = useAuth()
   const { authenticatedCall, loading, error } = useApi()
   const router = useRouter()
   const [growthRecord, setGrowthRecord] = useState<GrowthRecord | null>(null)
@@ -116,6 +116,28 @@ export default function GrowthRecordDetail({ id }: Props) {
       default:
         return 'bg-gray-100 text-gray-800'
     }
+  }
+
+  // JWT有効性チェック付きボタンハンドラー
+  const handleEditButtonClick = () => {
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
+    setIsEditModalOpen(true)
+  }
+
+  const handleDeleteButtonClick = () => {
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
+    setIsDeleteDialogOpen(true)
+  }
+
+  const handleCreatePostButtonClick = () => {
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
+    setIsCreatePostModalOpen(true)
   }
 
   const formatDate = (dateString: string) => {
@@ -199,13 +221,13 @@ export default function GrowthRecordDetail({ id }: Props) {
           {user && user.id === growthRecord.user.id && (
             <div className="flex space-x-2">
               <button
-                onClick={() => setIsEditModalOpen(true)}
+                onClick={handleEditButtonClick}
                 className="px-4 py-2 text-sm text-orange-600 bg-orange-50 rounded hover:bg-orange-100 transition-colors"
               >
                 編集
               </button>
               <button
-                onClick={() => setIsDeleteDialogOpen(true)}
+                onClick={handleDeleteButtonClick}
                 className="px-4 py-2 text-sm text-red-600 bg-red-50 rounded hover:bg-red-100 transition-colors"
               >
                 削除
@@ -246,7 +268,7 @@ export default function GrowthRecordDetail({ id }: Props) {
           </h2>
           {user && user.id === growthRecord.user.id && (
             <button
-              onClick={() => setIsCreatePostModalOpen(true)}
+              onClick={handleCreatePostButtonClick}
               className="px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-md transition-colors"
             >
               ＋ 成長メモを作成

--- a/frontend/src/components/growth-records/GrowthRecordList.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordList.tsx
@@ -31,7 +31,7 @@ interface PaginationInfo {
 }
 
 export default function GrowthRecordList() {
-  const { user } = useAuth()
+  const { user, checkTokenValidity } = useAuth()
   const { authenticatedCall, loading, error } = useApi()
   const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
   const [loadingMore, setLoadingMore] = useState(false)
@@ -86,6 +86,14 @@ export default function GrowthRecordList() {
     fetchGrowthRecords()
   }
 
+  const handleCreateButtonClick = () => {
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
+    setIsModalOpen(true)
+  }
+
   if (loading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -107,7 +115,7 @@ export default function GrowthRecordList() {
       {/* 記録を始めるボタン */}
       <div className="flex justify-center mb-6">
         <button
-          onClick={() => setIsModalOpen(true)}
+          onClick={handleCreateButtonClick}
           className="bg-green-500 hover:bg-green-600 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
         >
           ＋ 記録を始める

--- a/frontend/src/components/growth-records/GrowthRecordList.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordList.tsx
@@ -31,7 +31,7 @@ interface PaginationInfo {
 }
 
 export default function GrowthRecordList() {
-  const { user, checkTokenValidity } = useAuth()
+  const { user, executeProtected } = useAuth()
   const { authenticatedCall, loading, error } = useApi()
   const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
   const [loadingMore, setLoadingMore] = useState(false)
@@ -87,11 +87,9 @@ export default function GrowthRecordList() {
   }
 
   const handleCreateButtonClick = () => {
-    // JWT有効性を事前チェック
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
-    setIsModalOpen(true)
+    executeProtected(() => {
+      setIsModalOpen(true)
+    })
   }
 
   if (loading) {

--- a/frontend/src/components/layout/HamburgerMenu.tsx
+++ b/frontend/src/components/layout/HamburgerMenu.tsx
@@ -10,17 +10,13 @@ interface HamburgerMenuProps {
 }
 
 export default function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
-  const { user, checkTokenValidity } = useAuth()
+  const { user } = useAuth()
   const { logout } = useApi()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   
 
   const handleLogout = async () => {
-    // JWT有効性を事前チェック（期限切れでもログアウトは実行）
-    if (!checkTokenValidity()) {
-      console.log('JWT期限切れでもログアウト処理を継続')
-    }
-    
+    // ログアウトはJWT期限切れでも実行するため、直接処理
     try {
       setIsLoggingOut(true)
       console.log('ログアウト開始')

--- a/frontend/src/components/layout/HamburgerMenu.tsx
+++ b/frontend/src/components/layout/HamburgerMenu.tsx
@@ -10,12 +10,17 @@ interface HamburgerMenuProps {
 }
 
 export default function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
-  const { user } = useAuth()
+  const { user, checkTokenValidity } = useAuth()
   const { logout } = useApi()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   
 
   const handleLogout = async () => {
+    // JWT有効性を事前チェック（期限切れでもログアウトは実行）
+    if (!checkTokenValidity()) {
+      console.log('JWT期限切れでもログアウト処理を継続')
+    }
+    
     try {
       setIsLoggingOut(true)
       console.log('ログアウト開始')

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -50,7 +50,7 @@ export default function CreatePostModal({
   editData, 
   preselectedGrowthRecordId 
 }: Props) {
-  const { user } = useAuth()
+  const { } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
   const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
 
@@ -62,6 +62,18 @@ export default function CreatePostModal({
     category_id: '',
     post_type: 'growth_record_post' as 'growth_record_post' | 'general_post'
   })
+
+  const fetchGrowthRecords = useCallback(async () => {
+    try {
+      const data = await authenticatedCall('/api/v1/growth_records?per_page=100')
+      
+      if (data) {
+        setGrowthRecords(data.growth_records || [])
+      }
+    } catch (err) {
+      console.error('Error fetching growth records:', err)
+    }
+  }, [authenticatedCall])
 
   // データ取得とフォーム初期化
   useEffect(() => {
@@ -86,19 +98,7 @@ export default function CreatePostModal({
         }))
       }
     }
-  }, [isOpen, editData, preselectedGrowthRecordId])
-
-  const fetchGrowthRecords = useCallback(async () => {
-    try {
-      const data = await authenticatedCall('/api/v1/growth_records?per_page=100')
-      
-      if (data) {
-        setGrowthRecords(data.growth_records || [])
-      }
-    } catch (err) {
-      console.error('Error fetching growth records:', err)
-    }
-  }, [authenticatedCall])
+  }, [isOpen, editData, preselectedGrowthRecordId, fetchGrowthRecords])
 
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
-import { API_BASE_URL } from '@/lib/api'
+import { useApi } from '@/hooks/useApi'
 
 interface GrowthRecord {
   id: number
@@ -50,10 +50,9 @@ export default function CreatePostModal({
   editData, 
   preselectedGrowthRecordId 
 }: Props) {
-  const { token } = useAuth()
+  const { user } = useAuth()
+  const { authenticatedCall, loading, error, clearError } = useApi()
   const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   // フォーム状態
   const [formData, setFormData] = useState({
@@ -91,42 +90,33 @@ export default function CreatePostModal({
 
   const fetchGrowthRecords = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/growth_records?per_page=100`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
+      const data = await authenticatedCall('/api/v1/growth_records?per_page=100')
+      
+      if (data) {
         setGrowthRecords(data.growth_records || [])
       }
     } catch (err) {
       console.error('Error fetching growth records:', err)
     }
-  }, [token])
+  }, [authenticatedCall])
 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setLoading(true)
-    setError(null)
+    clearError()
 
     try {
       const isEditMode = !!editData
-      const url = isEditMode 
-        ? `${API_BASE_URL}/api/v1/posts/${editData.id}`
-        : `${API_BASE_URL}/api/v1/posts`
+      const endpoint = isEditMode 
+        ? `/api/v1/posts/${editData.id}`
+        : '/api/v1/posts'
       
       const method = isEditMode ? 'PUT' : 'POST'
 
-      const response = await fetch(url, {
+      const data = await authenticatedCall(endpoint, {
         method: method,
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           post: {
@@ -139,19 +129,13 @@ export default function CreatePostModal({
         })
       })
 
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || `投稿の${isEditMode ? '更新' : '作成'}に失敗しました`)
+      if (data) {
+        // 成功時
+        onSuccess()
+        handleClose()
       }
-
-      // 成功時
-      onSuccess()
-      handleClose()
     } catch (err) {
       console.error(`Error ${editData ? 'updating' : 'creating'} post:`, err)
-      setError(err instanceof Error ? err.message : `投稿の${editData ? '更新' : '作成'}に失敗しました`)
-    } finally {
-      setLoading(false)
     }
   }
 
@@ -163,7 +147,7 @@ export default function CreatePostModal({
       category_id: '',
       post_type: 'growth_record_post'
     })
-    setError(null)
+    clearError()
     onClose()
   }
 

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -50,7 +50,7 @@ export default function CreatePostModal({
   editData, 
   preselectedGrowthRecordId 
 }: Props) {
-  const { } = useAuth()
+  const { checkTokenValidity } = useAuth()
   const { authenticatedCall, loading, error, clearError } = useApi()
   const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
 
@@ -104,6 +104,11 @@ export default function CreatePostModal({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     clearError()
+
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
 
     try {
       const isEditMode = !!editData

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -38,7 +38,7 @@ interface PaginationInfo {
 }
 
 export default function Timeline() {
-  const { user, checkTokenValidity } = useAuth()
+  const { user, executeProtected } = useAuth()
   const { publicCall, loading, error } = usePublicApi()
   const [posts, setPosts] = useState<Post[]>([])
   const [loadingMore, setLoadingMore] = useState(false)
@@ -92,11 +92,9 @@ export default function Timeline() {
   }
 
   const handleCreateButtonClick = () => {
-    // JWT有効性を事前チェック
-    if (!checkTokenValidity()) {
-      return // 自動ログアウトが実行されるため処理中断
-    }
-    setIsCreateModalOpen(true)
+    executeProtected(() => {
+      setIsCreateModalOpen(true)
+    })
   }
 
   if (loading) {

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -38,7 +38,7 @@ interface PaginationInfo {
 }
 
 export default function Timeline() {
-  const { user } = useAuth()
+  const { user, checkTokenValidity } = useAuth()
   const { publicCall, loading, error } = usePublicApi()
   const [posts, setPosts] = useState<Post[]>([])
   const [loadingMore, setLoadingMore] = useState(false)
@@ -54,7 +54,7 @@ export default function Timeline() {
       
       const data = await publicCall(`/api/v1/posts?page=${page}&per_page=10`)
       
-      if (data.posts && data.pagination) {
+      if (data && data.posts && data.pagination) {
         if (append) {
           setPosts(prev => [...prev, ...data.posts])
         } else {
@@ -89,6 +89,14 @@ export default function Timeline() {
   const handleCreateSuccess = () => {
     // 投稿作成成功時にタイムラインを再取得
     fetchPosts()
+  }
+
+  const handleCreateButtonClick = () => {
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      return // 自動ログアウトが実行されるため処理中断
+    }
+    setIsCreateModalOpen(true)
   }
 
   if (loading) {
@@ -152,7 +160,7 @@ export default function Timeline() {
         <div className="fixed bottom-28 left-1/2 transform -translate-x-1/2 w-full max-w-2xl px-4 pointer-events-none z-40">
           <div className="flex justify-end">
             <button
-              onClick={() => setIsCreateModalOpen(true)}
+              onClick={handleCreateButtonClick}
               className="w-14 h-14 bg-green-500 hover:bg-green-600 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center pointer-events-auto"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -46,7 +46,7 @@ export default function Timeline() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const observer = useRef<IntersectionObserver | null>(null)
 
-  const fetchPosts = async (page: number = 1, append: boolean = false) => {
+  const fetchPosts = useCallback(async (page: number = 1, append: boolean = false) => {
     try {
       if (page > 1) {
         setLoadingMore(true)
@@ -67,7 +67,7 @@ export default function Timeline() {
     } finally {
       setLoadingMore(false)
     }
-  }
+  }, [publicCall])
 
   const lastPostElementRef = useCallback((node: HTMLDivElement | null) => {
     if (loading || loadingMore) return
@@ -80,11 +80,11 @@ export default function Timeline() {
     })
     
     if (node) observer.current.observe(node)
-  }, [loading, loadingMore, pagination])
+  }, [loading, loadingMore, pagination, fetchPosts])
 
   useEffect(() => {
     fetchPosts()
-  }, [])
+  }, [fetchPosts])
 
   const handleCreateSuccess = () => {
     // 投稿作成成功時にタイムラインを再取得

--- a/frontend/src/components/ui/AutoLogoutModal.tsx
+++ b/frontend/src/components/ui/AutoLogoutModal.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface AutoLogoutModalProps {
+  isOpen: boolean
+  message: string
+  onConfirm: () => void
+}
+
+export default function AutoLogoutModal({ isOpen, message, onConfirm }: AutoLogoutModalProps) {
+  const [countdown, setCountdown] = useState(10)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCountdown(10)
+      return
+    }
+
+    const timer = setInterval(() => {
+      setCountdown(prev => {
+        if (prev <= 1) {
+          clearInterval(timer)
+          onConfirm()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [isOpen, onConfirm])
+
+  if (!isOpen) return null
+
+  return (
+    <div 
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        backdropFilter: 'blur(4px)'
+      }}
+    >
+      <div className="bg-white rounded-lg shadow-xl max-w-sm w-full">
+        <div className="p-6">
+          {/* アイコン */}
+          <div className="flex justify-center mb-4">
+            <div className="w-16 h-16 bg-orange-100 rounded-full flex items-center justify-center">
+              <svg className="w-8 h-8 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+              </svg>
+            </div>
+          </div>
+
+          {/* メッセージ */}
+          <div className="text-center mb-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              セッション終了
+            </h2>
+            <p className="text-gray-600 text-sm mb-4">
+              {message}
+            </p>
+            <p className="text-sm text-gray-500">
+              {countdown}秒後にログイン画面に移動します
+            </p>
+          </div>
+
+          {/* プログレスバー */}
+          <div className="w-full bg-gray-200 rounded-full h-2 mb-4">
+            <div 
+              className="bg-orange-500 h-2 rounded-full transition-all duration-1000"
+              style={{ width: `${((10 - countdown) / 10) * 100}%` }}
+            />
+          </div>
+
+          {/* ボタン */}
+          <div className="flex justify-center">
+            <button
+              onClick={onConfirm}
+              className="px-6 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 transition-colors"
+            >
+              今すぐログイン画面へ
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/AutoLogoutModalContainer.tsx
+++ b/frontend/src/components/ui/AutoLogoutModalContainer.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useAuth } from '@/contexts/AuthContext'
+import AutoLogoutModal from './AutoLogoutModal'
+
+export default function AutoLogoutModalContainer() {
+  const { showAutoLogoutModal, autoLogoutMessage, confirmAutoLogout } = useAuth()
+
+  return (
+    <AutoLogoutModal
+      isOpen={showAutoLogoutModal}
+      message={autoLogoutMessage || 'セッションの有効期限が切れました。'}
+      onConfirm={confirmAutoLogout}
+    />
+  )
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { authenticatedApiCall, apiCall } from '@/lib/api'
 
@@ -9,7 +9,7 @@ export function useApi() {
   const [error, setError] = useState<string | null>(null)
 
   // 認証付きAPI呼び出し関数
-  const authenticatedCall = async (endpoint: string, options: RequestInit = {}) => {
+  const authenticatedCall = useCallback(async (endpoint: string, options: RequestInit = {}) => {
     if (!token) {
       setError('認証トークンがありません')
       return null
@@ -37,10 +37,10 @@ export function useApi() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [token])
 
   // ログアウトAPI専用関数
-  const logout = async () => {
+  const logout = useCallback(async () => {
     if (!token) {
       throw new Error('トークンがありません')
     }
@@ -48,14 +48,16 @@ export function useApi() {
     return authenticatedCall('/api/v1/auth/logout', {
       method: 'DELETE'
     })
-  }
+  }, [token, authenticatedCall])
+
+  const clearError = useCallback(() => setError(null), [])
 
   return {
     authenticatedCall,
     logout,
     loading,
     error,
-    clearError: () => setError(null)
+    clearError
   }
 }
 
@@ -64,7 +66,7 @@ export function usePublicApi() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const publicCall = async (endpoint: string, options: RequestInit = {}) => {
+  const publicCall = useCallback(async (endpoint: string, options: RequestInit = {}) => {
     setLoading(true)
     setError(null)
 
@@ -84,12 +86,14 @@ export function usePublicApi() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  const clearError = useCallback(() => setError(null), [])
 
   return {
     publicCall,
     loading,
     error,
-    clearError: () => setError(null)
+    clearError
   }
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -4,7 +4,7 @@ import { authenticatedApiCall, apiCall } from '@/lib/api'
 
 // 認証付きAPI呼び出し用のカスタムフック（強化版）
 export function useApi() {
-  const { token } = useAuth()
+  const { token, checkTokenValidity } = useAuth()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -12,6 +12,12 @@ export function useApi() {
   const authenticatedCall = useCallback(async (endpoint: string, options: RequestInit = {}) => {
     if (!token) {
       setError('認証トークンがありません')
+      return null
+    }
+
+    // JWT有効性を事前チェック
+    if (!checkTokenValidity()) {
+      setError('認証の有効期限が切れています')
       return null
     }
 
@@ -37,7 +43,7 @@ export function useApi() {
     } finally {
       setLoading(false)
     }
-  }, [token])
+  }, [token, checkTokenValidity])
 
   // ログアウトAPI専用関数
   const logout = useCallback(async () => {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,26 +1,42 @@
+import { useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
-import { API_BASE_URL } from '@/lib/api'
+import { authenticatedApiCall, apiCall } from '@/lib/api'
 
-// 認証付きAPI呼び出し用のカスタムフック
+// 認証付きAPI呼び出し用のカスタムフック（強化版）
 export function useApi() {
   const { token } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   // 認証付きAPI呼び出し関数
   const authenticatedCall = async (endpoint: string, options: RequestInit = {}) => {
-    const url = `${API_BASE_URL}${endpoint}`
-    
-    const defaultHeaders = {
-      'Content-Type': 'application/json',
-      ...(token && { 'Authorization': `Bearer ${token}` })
+    if (!token) {
+      setError('認証トークンがありません')
+      return null
     }
 
-    return fetch(url, {
-      ...options,
-      headers: {
-        ...defaultHeaders,
-        ...options.headers,
-      },
-    })
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await authenticatedApiCall(endpoint, token, options)
+      
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`API Error: ${response.status} ${errorText}`)
+      }
+
+      const data = await response.json()
+      return data
+    } catch (err) {
+      if (err instanceof Error && err.message === 'JWT_EXPIRED') {
+        return null
+      }
+      setError(err instanceof Error ? err.message : '予期しないエラーが発生しました')
+      return null
+    } finally {
+      setLoading(false)
+    }
   }
 
   // ログアウトAPI専用関数
@@ -36,6 +52,44 @@ export function useApi() {
 
   return {
     authenticatedCall,
-    logout
+    logout,
+    loading,
+    error,
+    clearError: () => setError(null)
+  }
+}
+
+// 認証不要API用カスタムフック
+export function usePublicApi() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const publicCall = async (endpoint: string, options: RequestInit = {}) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await apiCall(endpoint, options)
+      
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`API Error: ${response.status} ${errorText}`)
+      }
+
+      const data = await response.json()
+      return data
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '予期しないエラーが発生しました')
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    publicCall,
+    loading,
+    error,
+    clearError: () => setError(null)
   }
 }


### PR DESCRIPTION
### 概要
  JWT期限切れ時の自動ログアウト機能を全コンポーネントに適用し、APIアクセスを統一フックに移行。併せて認証チェック処理の冗長な記述をリファクタリング

  ### 変更内容
  - Timeline.tsx: 直接fetchをusePublicApiフックに変更（認証不要API用）
  - GrowthRecordList.tsx: 直接fetchをuseApiフックに変更（認証必要API用）
  - GrowthRecordDetail.tsx: 直接fetchをuseApiフックに変更
  - CreatePostModal.tsx: 直接fetchをuseApiフックに変更
  - DeleteConfirmDialog.tsx: 直接fetchをuseApiフックに変更
  - CreateGrowthRecordModal.tsx: 植物取得はusePublicApi、成長記録操作はuseApiに変更
  - 全コンポーネントで独自のloading/error stateを削除し、フックの統一管理に移行
  - 手動での認証ヘッダー設定を削除（フックが自動処理）
  - JWT認証チェック処理の重複コードを削除し、AuthContextに`executeProtected`/`executeProtectedAsync`として統合
  - 自動ログアウト時に視覚的モーダル（10秒カウントダウン + プログレスバー付き）を表示
  - lib/api.tsでJWT期限切れ（422エラー）を自動検知し、自動ログアウトを実行
  - AuthContextに6ヶ月間の非アクティブ検知機能を追加

  ### 動作確認
  - [ ] JWT期限切れ時にモーダル表示後、自動ログアウトされることを確認
  - [ ] ログアウト後、適切なページにリダイレクトされることを確認
  - [ ] 各コンポーネントで従来通りの機能が動作することを確認
  - [ ] 6ヶ月間非アクティブ時の自動ログアウトが正常に動作することを確認

  ### 確認依頼
  - [ ] JWT期限切れ検知ロジックが正しく動作するか
  - [ ] 統一APIフック使用により、コードの重複が適切に除去されているか
  - [ ] 認証チェック処理の冗長性が解消されているか
  - [ ] エラーハンドリングが統一され、ユーザビリティが向上しているか
  - [ ] 認証が必要なAPIと不要なAPIが適切に分離されているか
  - [ ] 自動ログアウトモーダルのUXが適切に機能するか


### CloseしたいIssue
Close #113 