### PR TITLE
feat: フロントエンドのメール認証機能を実装

### DIFF
--- a/backend/test/mailers/user_mailer_test.rb
+++ b/backend/test/mailers/user_mailer_test.rb
@@ -2,10 +2,18 @@ require "test_helper"
 
 class UserMailerTest < ActionMailer::TestCase
   test "email_verification" do
-    mail = UserMailer.email_verification
-    assert_equal "Email verification", mail.subject
-    assert_equal [ "to@example.org" ], mail.to
-    assert_equal [ "from@example.com" ], mail.from
-    assert_match "Hi", mail.body.encoded
+    user = User.create!(
+      name: "Test User",
+      email: "test@example.com",
+      password: "password123"
+    )
+    verification_url = "http://localhost:3001/verify-email?token=test_token"
+    
+    mail = UserMailer.email_verification(user, verification_url)
+    
+    assert_equal "【おうちの畑】メールアドレス認証のお願い", mail.subject
+    assert_equal [ "test@example.com" ], mail.to
+    assert_equal [ "ouchi.no.hatake@gmail.com" ], mail.from
+    assert_match "認証", mail.body.encoded
   end
 end

--- a/backend/test/mailers/user_mailer_test.rb
+++ b/backend/test/mailers/user_mailer_test.rb
@@ -8,9 +8,9 @@ class UserMailerTest < ActionMailer::TestCase
       password: "password123"
     )
     verification_url = "http://localhost:3001/verify-email?token=test_token"
-    
+
     mail = UserMailer.email_verification(user, verification_url)
-    
+
     assert_equal "【おうちの畑】メールアドレス認証のお願い", mail.subject
     assert_equal [ "test@example.com" ], mail.to
     assert_equal [ "ouchi.no.hatake@gmail.com" ], mail.from

--- a/frontend/src/app/signup-success/page.tsx
+++ b/frontend/src/app/signup-success/page.tsx
@@ -37,7 +37,7 @@ export default function SignupSuccessPage() {
       } else {
         setResendMessage(result.error || '再送信に失敗しました')
       }
-    } catch (error) {
+    } catch {
       setResendMessage('予期しないエラーが発生しました')
     } finally {
       setIsResending(false)

--- a/frontend/src/app/signup-success/page.tsx
+++ b/frontend/src/app/signup-success/page.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+
+export default function SignupSuccessPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { resendVerification } = useAuth()
+  
+  const [email, setEmail] = useState<string>('')
+  const [isResending, setIsResending] = useState(false)
+  const [resendMessage, setResendMessage] = useState<string>('')
+
+  useEffect(() => {
+    // URLパラメータからメールアドレスを取得
+    const emailParam = searchParams.get('email')
+    if (emailParam) {
+      setEmail(emailParam)
+    }
+  }, [searchParams])
+
+  const handleResendEmail = async () => {
+    if (!email.trim()) {
+      setResendMessage('メールアドレスが設定されていません')
+      return
+    }
+
+    setIsResending(true)
+    setResendMessage('')
+    
+    try {
+      const result = await resendVerification(email)
+      if (result.success) {
+        setResendMessage('認証メールを再送信しました。メールボックスをご確認ください。')
+      } else {
+        setResendMessage(result.error || '再送信に失敗しました')
+      }
+    } catch (error) {
+      setResendMessage('予期しないエラーが発生しました')
+    } finally {
+      setIsResending(false)
+    }
+  }
+
+  const handleBackToLogin = () => {
+    router.push('/login')
+  }
+
+  const handleBackToSignup = () => {
+    router.push('/signup')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          ユーザー登録完了
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          
+          <div className="text-center">
+            {/* 成功アイコン */}
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
+              <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+              </svg>
+            </div>
+
+            <h3 className="mt-4 text-lg font-medium text-gray-900">
+              確認メールを送信しました
+            </h3>
+            
+            {email && (
+              <p className="mt-2 text-sm text-gray-600">
+                <strong>{email}</strong> 宛に確認メールを送信しました。
+              </p>
+            )}
+            
+            <div className="mt-4 text-sm text-gray-600 space-y-2">
+              <p>📧 メールボックスをご確認ください</p>
+              <p>🔗 メール内のリンクをクリックして認証を完了してください</p>
+              <p>⏰ メール認証リンクの有効期限は<strong>24時間</strong>です</p>
+            </div>
+
+            {/* 重要な注意事項 */}
+            <div className="mt-6 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+              <div className="flex items-start">
+                <div className="flex-shrink-0">
+                  <svg className="h-5 w-5 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+                  </svg>
+                </div>
+                <div className="ml-3">
+                  <h4 className="text-sm font-medium text-yellow-800">重要</h4>
+                  <div className="mt-1 text-sm text-yellow-700">
+                    <p>メール認証が完了するまでログインできません。</p>
+                    <p>期限が過ぎた場合は、再度登録が必要になります。</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 再送信セクション */}
+            <div className="mt-6 pt-6 border-t border-gray-200">
+              <h4 className="text-sm font-medium text-gray-900 mb-3">
+                メールが届かない場合
+              </h4>
+              
+              {resendMessage && (
+                <div className={`mb-4 p-3 rounded-md text-sm ${
+                  resendMessage.includes('再送信しました') 
+                    ? 'bg-green-100 text-green-700 border border-green-200'
+                    : 'bg-red-100 text-red-700 border border-red-200'
+                }`}>
+                  {resendMessage}
+                </div>
+              )}
+
+              <button
+                onClick={handleResendEmail}
+                disabled={isResending || !email}
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isResending ? '送信中...' : '認証メールを再送信'}
+              </button>
+
+              <div className="mt-4 text-xs text-gray-500 space-y-1">
+                <p>• 迷惑メールフォルダもご確認ください</p>
+                <p>• メールアドレスに間違いがないかご確認ください</p>
+              </div>
+            </div>
+
+            {/* ナビゲーションボタン */}
+            <div className="mt-8 pt-6 border-t border-gray-200 space-y-3">
+              <button
+                onClick={handleBackToLogin}
+                className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                ログイン画面へ戻る
+              </button>
+              
+              <button
+                onClick={handleBackToSignup}
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+              >
+                新規登録画面へ戻る
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -6,10 +6,12 @@ import { registerSchema, type RegisterFormData } from '@/lib/validation'
 import { apiCall } from '@/lib/api'
 import { useAuth } from '@/contexts/AuthContext'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function SignupPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+  const router = useRouter()
 
   const { login } = useAuth()
 
@@ -35,11 +37,15 @@ export default function SignupPage() {
         const result = await response.json()
         console.log('📝 新規登録成功:', result)
 
-        // useAuthのlogin関数を使ってJWT保存
-        login(result.token, result.user)
-        
-        // 新規登録成功時の遷移（フラッシュメッセージ付き）
-        window.location.href = '/?flash_message=' + encodeURIComponent('新規登録が完了しました') + '&flash_type=success'
+        // バックエンドがrequires_verification: trueを返す場合
+        if (result.requires_verification) {
+          // メール認証が必要な場合は案内画面へ遷移
+          router.push(`/signup-success?email=${encodeURIComponent(result.user.email)}`)
+        } else {
+          // 古いフロー（念のため残す）- 即座にログイン
+          login(result.token, result.user)
+          window.location.href = '/?flash_message=' + encodeURIComponent('新規登録が完了しました') + '&flash_type=success'
+        }
       } else {
         const error = await response.json()
         setApiError(error.message || '新規登録に失敗しました')

--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+
+export default function VerifyEmailPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { verifyEmail, resendVerification } = useAuth()
+  
+  const [status, setStatus] = useState<'loading' | 'success' | 'error' | 'expired'>('loading')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [email, setEmail] = useState<string>('')
+  const [isResending, setIsResending] = useState(false)
+
+  useEffect(() => {
+    const token = searchParams.get('token')
+    
+    if (!token) {
+      setStatus('error')
+      setErrorMessage('認証トークンが見つかりません')
+      return
+    }
+
+    // メール認証を実行
+    const performVerification = async () => {
+      try {
+        const result = await verifyEmail(token)
+        
+        if (result.success) {
+          setStatus('success')
+          // 3秒後にタイムラインへリダイレクト
+          setTimeout(() => {
+            router.push('/')
+          }, 3000)
+        } else {
+          if (result.expired) {
+            setStatus('expired')
+          } else {
+            setStatus('error')
+          }
+          setErrorMessage(result.error || '認証に失敗しました')
+        }
+      } catch (error) {
+        setStatus('error')
+        setErrorMessage('予期しないエラーが発生しました')
+      }
+    }
+
+    performVerification()
+  }, [searchParams, verifyEmail, router])
+
+  const handleResendEmail = async () => {
+    if (!email.trim()) {
+      alert('メールアドレスを入力してください')
+      return
+    }
+
+    setIsResending(true)
+    try {
+      const result = await resendVerification(email)
+      if (result.success) {
+        alert('認証メールを再送信しました。メールボックスをご確認ください。')
+      } else {
+        alert(result.error || '再送信に失敗しました')
+      }
+    } catch (error) {
+      alert('予期しないエラーが発生しました')
+    } finally {
+      setIsResending(false)
+    }
+  }
+
+  const handleBackToSignup = () => {
+    router.push('/signup')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          メールアドレス認証
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          
+          {status === 'loading' && (
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600 mx-auto"></div>
+              <p className="mt-4 text-gray-600">認証を確認中...</p>
+            </div>
+          )}
+
+          {status === 'success' && (
+            <div className="text-center">
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
+                <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
+                </svg>
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">認証完了</h3>
+              <p className="mt-2 text-sm text-gray-600">
+                メールアドレスの認証が完了しました。<br />
+                3秒後にタイムラインへ移動します...
+              </p>
+              <button
+                onClick={() => router.push('/')}
+                className="mt-4 w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+              >
+                今すぐタイムラインへ
+              </button>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div className="text-center">
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+                <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">認証エラー</h3>
+              <p className="mt-2 text-sm text-gray-600">{errorMessage}</p>
+              
+              <div className="mt-6">
+                <h4 className="text-sm font-medium text-gray-900 mb-3">認証メールを再送信</h4>
+                <input
+                  type="email"
+                  placeholder="メールアドレス"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500"
+                />
+                <button
+                  onClick={handleResendEmail}
+                  disabled={isResending}
+                  className="mt-3 w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+                >
+                  {isResending ? '送信中...' : '認証メール再送信'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {status === 'expired' && (
+            <div className="text-center">
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-yellow-100">
+                <svg className="h-6 w-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+                </svg>
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">認証期限切れ</h3>
+              <p className="mt-2 text-sm text-gray-600">
+                {errorMessage}<br />
+                <strong>再登録が必要です</strong>
+              </p>
+              <button
+                onClick={handleBackToSignup}
+                className="mt-4 w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
+              >
+                新規登録画面へ戻る
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -42,7 +42,7 @@ export default function VerifyEmailPage() {
           }
           setErrorMessage(result.error || '認証に失敗しました')
         }
-      } catch (error) {
+      } catch {
         setStatus('error')
         setErrorMessage('予期しないエラーが発生しました')
       }
@@ -65,7 +65,7 @@ export default function VerifyEmailPage() {
       } else {
         alert(result.error || '再送信に失敗しました')
       }
-    } catch (error) {
+    } catch {
       alert('予期しないエラーが発生しました')
     } finally {
       setIsResending(false)


### PR DESCRIPTION
### 概要
  フロントエンドのメール認証機能を実装し、新規登録後のメール認証フローを完成

  ### 変更内容
  - AuthContextにverifyEmailとresendVerification関数を追加し、メール認証APIとの連携を実装
  - /verify-emailページを新規作成（認証処理、成功・エラー・期限切れ状態の管理とUI）
  - /signup-successページを新規作成（登録完了案内、再送信機能、ユーザーガイダンス）
  - 新規登録フロー（signup/page.tsx）をメール認証必須に更新し、適切な画面遷移を実装
  - User型にemail_verified属性を追加し、認証状態を管理

  ### 動作確認
  - 新規登録後にsignup-success画面が正常に表示される
  - メール認証リンククリック後にverify-email画面で認証処理が実行される
  - 認証成功時に3秒後にタイムラインへ自動リダイレクトされる
  - 期限切れトークンで「再登録が必要です」メッセージが表示される
  - 認証メール再送信機能が正常に動作する
  - 既存のログイン・ログアウト機能に影響なし

### CloseしたいIssue
Close #106 