### PR TITLE
feat: 認証ミドルウェアにメール認証チェック機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/auth_controller.rb
+++ b/backend/app/controllers/api/v1/auth_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::AuthController < ApplicationController
   include ActionController::Cookies
   skip_before_action :authenticate_request, only: [ :register, :login, :verify, :logout, :verify_email, :resend_verification ]
+  skip_before_action :check_email_verification, only: [ :register, :login, :verify, :logout, :verify_email, :resend_verification ]
 
   # POST /api/v1/auth/register
   def register

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::PostsController < ApplicationController
   skip_before_action :authenticate_request, only: [ :index ]
+  skip_before_action :check_email_verification, only: [ :index ]
   before_action :set_post, only: [ :update, :destroy ]
 
   def index

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include ExceptionHandler
 
   before_action :authenticate_request
+  before_action :check_email_verification
 
   private
 
@@ -33,5 +34,17 @@ class ApplicationController < ActionController::API
   def current_token
     header = request.headers["Authorization"]
     header.split(" ").last if header
+  end
+
+  def check_email_verification
+    return unless @current_user
+
+    unless @current_user.email_verified?
+      render json: {
+        error: "メールアドレスの認証が完了していません。認証メールをご確認ください",
+        requires_verification: true,
+        email: @current_user.email
+      }, status: :forbidden
+    end
   end
 end

--- a/backend/test/controllers/api/v1/email_verification_middleware_test.rb
+++ b/backend/test/controllers/api/v1/email_verification_middleware_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class Api::V1::EmailVerificationMiddlewareTest < ActionDispatch::IntegrationTest
   def setup
@@ -9,67 +9,67 @@ class Api::V1::EmailVerificationMiddlewareTest < ActionDispatch::IntegrationTest
       email_verified: true,
       email_verification_token: nil
     )
-    
+
     @unverified_user = User.create!(
-      name: "Unverified User", 
+      name: "Unverified User",
       email: "unverified@example.com",
       password: "password123",
       email_verified: false,
       email_verification_token: "test_token"
     )
-    
+
     @verified_token = JsonWebToken.encode(user_id: @verified_user.id)
     @unverified_token = JsonWebToken.encode(user_id: @unverified_user.id)
   end
-  
+
   test "メール認証済みユーザーはAPIアクセス可能" do
     post "/api/v1/posts", params: {
       post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
     }, headers: auth_headers(@verified_token)
     assert_response :created
   end
-  
+
   test "メール未認証ユーザーはAPIアクセス拒否される" do
     post "/api/v1/posts", params: {
       post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
     }, headers: auth_headers(@unverified_token)
     assert_response :forbidden
-    
+
     response_data = JSON.parse(response.body)
     assert_equal "メールアドレスの認証が完了していません。認証メールをご確認ください", response_data["error"]
     assert_equal true, response_data["requires_verification"]
     assert_equal @unverified_user.email, response_data["email"]
   end
-  
+
   test "認証関連エンドポイントはメール未認証でもアクセス可能" do
     # 登録
     post "/api/v1/auth/register", params: {
       user: { name: "Test User", email: "test@example.com", password: "password123" }
     }
     assert_response :created
-    
+
     # メール認証（無効なトークン）
     post "/api/v1/auth/verify-email", params: { token: "invalid_token" }
     # トークンが無効でもエンドポイント自体にはアクセス可能
     assert_response :unprocessable_entity
-    
+
     # 認証メール再送信
     post "/api/v1/auth/resend-verification", params: { email: @unverified_user.email }
     assert_response :ok
   end
-  
+
   test "トークンなしの場合は認証エラーが優先される" do
     post "/api/v1/posts", params: {
       post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
     }
     assert_response :unprocessable_entity
-    
+
     response_data = JSON.parse(response.body)
     assert_equal "トークンが提供されていません", response_data["message"]
   end
-  
+
   private
-  
+
   def auth_headers(token)
     { "Authorization" => "Bearer #{token}" }
   end

--- a/backend/test/controllers/api/v1/email_verification_middleware_test.rb
+++ b/backend/test/controllers/api/v1/email_verification_middleware_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class Api::V1::EmailVerificationMiddlewareTest < ActionDispatch::IntegrationTest
+  def setup
+    @verified_user = User.create!(
+      name: "Verified User",
+      email: "verified@example.com",
+      password: "password123",
+      email_verified: true,
+      email_verification_token: nil
+    )
+    
+    @unverified_user = User.create!(
+      name: "Unverified User", 
+      email: "unverified@example.com",
+      password: "password123",
+      email_verified: false,
+      email_verification_token: "test_token"
+    )
+    
+    @verified_token = JsonWebToken.encode(user_id: @verified_user.id)
+    @unverified_token = JsonWebToken.encode(user_id: @unverified_user.id)
+  end
+  
+  test "メール認証済みユーザーはAPIアクセス可能" do
+    post "/api/v1/posts", params: {
+      post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
+    }, headers: auth_headers(@verified_token)
+    assert_response :created
+  end
+  
+  test "メール未認証ユーザーはAPIアクセス拒否される" do
+    post "/api/v1/posts", params: {
+      post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
+    }, headers: auth_headers(@unverified_token)
+    assert_response :forbidden
+    
+    response_data = JSON.parse(response.body)
+    assert_equal "メールアドレスの認証が完了していません。認証メールをご確認ください", response_data["error"]
+    assert_equal true, response_data["requires_verification"]
+    assert_equal @unverified_user.email, response_data["email"]
+  end
+  
+  test "認証関連エンドポイントはメール未認証でもアクセス可能" do
+    # 登録
+    post "/api/v1/auth/register", params: {
+      user: { name: "Test User", email: "test@example.com", password: "password123" }
+    }
+    assert_response :created
+    
+    # メール認証（無効なトークン）
+    post "/api/v1/auth/verify-email", params: { token: "invalid_token" }
+    # トークンが無効でもエンドポイント自体にはアクセス可能
+    assert_response :unprocessable_entity
+    
+    # 認証メール再送信
+    post "/api/v1/auth/resend-verification", params: { email: @unverified_user.email }
+    assert_response :ok
+  end
+  
+  test "トークンなしの場合は認証エラーが優先される" do
+    post "/api/v1/posts", params: {
+      post: { title: "Test Post", content: "Test Content", post_type: "general_post" }
+    }
+    assert_response :unprocessable_entity
+    
+    response_data = JSON.parse(response.body)
+    assert_equal "トークンが提供されていません", response_data["message"]
+  end
+  
+  private
+  
+  def auth_headers(token)
+    { "Authorization" => "Bearer #{token}" }
+  end
+end


### PR DESCRIPTION
### 概要
  認証ミドルウェアにメール認証チェック機能を追加し、メール未認証ユーザーのAPIアクセスを制限

  ### 変更内容
  - ApplicationControllerにcheck_email_verificationフィルターを追加し、メール未認証ユーザーに403 Forbiddenエラーを返す機能を実装
  - AuthControllerの認証関連エンドポイント（register, login, verify-email等）をメール認証チェック対象外に設定
  - PostsControllerのindexアクションをメール認証チェック対象外に設定（パブリック表示のため）
  - 統一されたエラーレスポンス形式を実装（error, requires_verification, emailを含む）
  - メール認証ミドルウェアの動作を検証する包括的テストケースを追加

  ### 動作確認
  - メール認証済みユーザーは従来通りAPIにアクセス可能
  - メール未認証ユーザーがAPIアクセス時に403 Forbiddenエラーが返される
  - 認証関連エンドポイントはメール未認証でも正常にアクセス可能
  - PostsController#indexはメール認証不要でアクセス可能
  - 全テストケースが成功（4 tests, 10 assertions, 0 failures）

### 確認依頼
<!-- レビュー時に確認してほしいポイント -->
- [ ] 
- [ ] 
- [ ] 
- [ ] 

### 補足
<!-- レビュアーに伝えたいことがあれば -->

### 関連Issue
<!-- 関連するIssueがあれば -->

### CloseしたいIssue
Close #