### PR TITLE
feat: 認証メール再送信ページと未認証ユーザー向けUI制御を実装

### DIFF
--- a/backend/test/mailers/user_mailer_test.rb
+++ b/backend/test/mailers/user_mailer_test.rb
@@ -14,7 +14,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal "【おうちの畑】メールアドレス認証のお願い", mail.subject
     assert_equal [ "test@example.com" ], mail.to
     assert_equal [ "ouchi.no.hatake@gmail.com" ], mail.from
-    
+
     # マルチパートメールの場合、テキストパートを確認
     if mail.multipart?
       text_part = mail.text_part.body.to_s

--- a/backend/test/mailers/user_mailer_test.rb
+++ b/backend/test/mailers/user_mailer_test.rb
@@ -14,6 +14,13 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal "【おうちの畑】メールアドレス認証のお願い", mail.subject
     assert_equal [ "test@example.com" ], mail.to
     assert_equal [ "ouchi.no.hatake@gmail.com" ], mail.from
-    assert_match "認証", mail.body.encoded
+    
+    # マルチパートメールの場合、テキストパートを確認
+    if mail.multipart?
+      text_part = mail.text_part.body.to_s
+      assert_match /認証/, text_part
+    else
+      assert_match /認証/, mail.body.to_s
+    end
   end
 end

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,10 +6,14 @@ import { loginSchema, type LoginFormData } from '@/lib/validation'
 import { apiCall } from '@/lib/api'
 import { useAuth } from '@/contexts/AuthContext'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
+  const router = useRouter()
   const [isLoading, setIsLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+  const [requiresVerification, setRequiresVerification] = useState(false)
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string>('')
 
   const { login } = useAuth()
 
@@ -24,6 +28,8 @@ export default function LoginPage() {
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true)
     setApiError(null)
+    setRequiresVerification(false)
+    setUnverifiedEmail('')
 
     try {
       const response = await apiCall('/api/v1/auth/login', {
@@ -42,13 +48,23 @@ export default function LoginPage() {
         window.location.href = '/?flash_message=' + encodeURIComponent('ログインしました') + '&flash_type=success'
       } else {
         const error = await response.json()
-        setApiError(error.message || 'ログインに失敗しました')
+        setApiError(error.message || error.error || 'ログインに失敗しました')
+        
+        // メール認証が必要な場合の処理
+        if (error.requires_verification && error.email) {
+          setRequiresVerification(true)
+          setUnverifiedEmail(error.email)
+        }
       }
     } catch {
       setApiError('ネットワークエラーが発生しました')
     } finally {
       setIsLoading(false)
     }
+  }
+
+  const handleGoToResendPage = () => {
+    router.push(`/resend-verification?email=${encodeURIComponent(unverifiedEmail)}`)
   }
 
   return (
@@ -90,6 +106,18 @@ export default function LoginPage() {
           {apiError && (
             <div className="auth-api-error">
               {apiError}
+              {/* メール認証が必要な場合のリンク表示 */}
+              {requiresVerification && unverifiedEmail && (
+                <div className="mt-3 text-center">
+                  <button
+                    type="button"
+                    onClick={handleGoToResendPage}
+                    className="text-blue-600 hover:text-blue-800 underline text-sm"
+                  >
+                    認証メールを再送信する
+                  </button>
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,9 +2,10 @@
 
 import { useAuth } from '@/contexts/AuthContext'
 import Timeline from '@/components/timeline/Timeline'
+import EmailVerificationBanner from '@/components/auth/EmailVerificationBanner'
 
 export default function HomePage() {
-  const { isLoading } = useAuth()
+  const { isLoading, user, isAuthenticated } = useAuth()
 
   if (isLoading) {
     return (
@@ -14,5 +15,13 @@ export default function HomePage() {
     )
   }
 
-  return <Timeline />
+  return (
+    <>
+      {/* メール未認証の場合の警告バナー */}
+      {isAuthenticated && user && !user.email_verified && (
+        <EmailVerificationBanner email={user.email} />
+      )}
+      <Timeline />
+    </>
+  )
 }

--- a/frontend/src/app/resend-verification/page.tsx
+++ b/frontend/src/app/resend-verification/page.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useAuth } from '@/contexts/AuthContext'
+
+// バリデーションスキーマ
+const resendVerificationSchema = z.object({
+  email: z.string().email('有効なメールアドレスを入力してください')
+})
+
+type ResendVerificationFormData = z.infer<typeof resendVerificationSchema>
+
+export default function ResendVerificationPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { resendVerification } = useAuth()
+  
+  const [isResending, setIsResending] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string>('')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [lastSentTime, setLastSentTime] = useState<number | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue
+  } = useForm<ResendVerificationFormData>({
+    resolver: zodResolver(resendVerificationSchema)
+  })
+
+  // URLパラメータからメールアドレスを取得して自動設定
+  useEffect(() => {
+    const emailParam = searchParams.get('email')
+    if (emailParam) {
+      setValue('email', emailParam)
+    }
+  }, [searchParams, setValue])
+
+  const canResend = () => {
+    if (!lastSentTime) return true
+    const now = Date.now()
+    const timeDiff = now - lastSentTime
+    const waitTime = 60 * 1000 // 60秒
+    return timeDiff >= waitTime
+  }
+
+  const getRemainingWaitTime = () => {
+    if (!lastSentTime) return 0
+    const now = Date.now()
+    const timeDiff = now - lastSentTime
+    const waitTime = 60 * 1000 // 60秒
+    return Math.max(0, Math.ceil((waitTime - timeDiff) / 1000))
+  }
+
+  const onSubmit = async (data: ResendVerificationFormData) => {
+    if (!canResend()) {
+      const remainingTime = getRemainingWaitTime()
+      setErrorMessage(`再送信は${remainingTime}秒後に可能です`)
+      return
+    }
+
+    setIsResending(true)
+    setErrorMessage('')
+    setSuccessMessage('')
+
+    try {
+      const result = await resendVerification(data.email)
+      
+      if (result.success) {
+        setSuccessMessage('認証メールを再送信しました。メールボックスをご確認ください。')
+        setLastSentTime(Date.now())
+      } else {
+        setErrorMessage(result.error || '再送信に失敗しました')
+      }
+    } catch {
+      setErrorMessage('予期しないエラーが発生しました')
+    } finally {
+      setIsResending(false)
+    }
+  }
+
+  const handleBackToLogin = () => {
+    router.push('/login')
+  }
+
+  const handleBackToSignup = () => {
+    router.push('/signup')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          認証メール再送信
+        </h2>
+        <p className="mt-2 text-center text-sm text-gray-600">
+          メールアドレスを入力して、認証メールを再送信してください
+        </p>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            
+            {/* メールアドレス入力 */}
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                メールアドレス
+              </label>
+              <div className="mt-1">
+                <input
+                  {...register('email')}
+                  type="email"
+                  autoComplete="email"
+                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  placeholder="example@email.com"
+                />
+                {errors.email && (
+                  <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+                )}
+              </div>
+            </div>
+
+            {/* 成功メッセージ */}
+            {successMessage && (
+              <div className="bg-green-100 border border-green-200 text-green-700 px-4 py-3 rounded-md text-sm">
+                <div className="flex items-start">
+                  <div className="flex-shrink-0">
+                    <svg className="h-5 w-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    {successMessage}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* エラーメッセージ */}
+            {errorMessage && (
+              <div className="bg-red-100 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+                <div className="flex items-start">
+                  <div className="flex-shrink-0">
+                    <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    {errorMessage}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* 送信ボタン */}
+            <div>
+              <button
+                type="submit"
+                disabled={isResending || !canResend()}
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isResending ? '送信中...' : 
+                 !canResend() ? `${getRemainingWaitTime()}秒後に送信可能` : 
+                 '認証メールを再送信'}
+              </button>
+            </div>
+
+            {/* 送信制限の説明 */}
+            {!canResend() && (
+              <div className="text-center text-sm text-gray-500">
+                連続送信を防ぐため、60秒間お待ちください
+              </div>
+            )}
+          </form>
+
+          {/* ナビゲーションリンク */}
+          <div className="mt-8 pt-6 border-t border-gray-200 space-y-3">
+            <button
+              onClick={handleBackToLogin}
+              className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              ログイン画面へ戻る
+            </button>
+            
+            <button
+              onClick={handleBackToSignup}
+              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              新規登録画面へ戻る
+            </button>
+          </div>
+
+          {/* 使用方法の説明 */}
+          <div className="mt-6 text-center">
+            <div className="text-xs text-gray-500 space-y-1">
+              <p>• 登録時に使用したメールアドレスを入力してください</p>
+              <p>• 迷惑メールフォルダもご確認ください</p>
+              <p>• メール認証リンクの有効期限は24時間です</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/auth/EmailVerificationBanner.tsx
+++ b/frontend/src/components/auth/EmailVerificationBanner.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+
+interface EmailVerificationBannerProps {
+  email: string
+}
+
+export default function EmailVerificationBanner({ email }: EmailVerificationBannerProps) {
+  const router = useRouter()
+  const { resendVerification } = useAuth()
+  const [isDismissed, setIsDismissed] = useState(false)
+  const [isResending, setIsResending] = useState(false)
+  const [resendMessage, setResendMessage] = useState<string>('')
+
+  if (isDismissed) {
+    return null
+  }
+
+  const handleResend = async () => {
+    setIsResending(true)
+    setResendMessage('')
+
+    try {
+      const result = await resendVerification(email)
+      if (result.success) {
+        setResendMessage('認証メールを再送信しました')
+      } else {
+        setResendMessage(result.error || '再送信に失敗しました')
+      }
+    } catch {
+      setResendMessage('予期しないエラーが発生しました')
+    } finally {
+      setIsResending(false)
+    }
+  }
+
+  const handleGoToResendPage = () => {
+    router.push('/resend-verification')
+  }
+
+  const handleDismiss = () => {
+    setIsDismissed(true)
+  }
+
+  return (
+    <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4">
+      <div className="flex items-start">
+        <div className="flex-shrink-0">
+          <svg className="h-5 w-5 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+          </svg>
+        </div>
+        <div className="ml-3 flex-1">
+          <h3 className="text-sm font-medium text-yellow-800">メールアドレスの認証が必要です</h3>
+          <div className="mt-1 text-sm text-yellow-700">
+            <p>
+              <strong>{email}</strong> 宛に送信した認証メールをご確認ください。
+              メールを確認して認証を完了すると、全ての機能をご利用いただけます。
+            </p>
+          </div>
+          
+          {resendMessage && (
+            <div className={`mt-2 text-sm ${
+              resendMessage.includes('再送信しました') 
+                ? 'text-green-700' 
+                : 'text-red-700'
+            }`}>
+              {resendMessage}
+            </div>
+          )}
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              onClick={handleResend}
+              disabled={isResending}
+              className="text-sm bg-yellow-100 text-yellow-800 px-3 py-1 rounded-md hover:bg-yellow-200 focus:outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-50"
+            >
+              {isResending ? '送信中...' : '認証メールを再送信'}
+            </button>
+            
+            <button
+              onClick={handleGoToResendPage}
+              className="text-sm bg-white text-yellow-800 px-3 py-1 rounded-md border border-yellow-300 hover:bg-yellow-50 focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            >
+              再送信ページへ
+            </button>
+          </div>
+        </div>
+        <div className="ml-auto pl-3">
+          <div className="-mx-1.5 -my-1.5">
+            <button
+              onClick={handleDismiss}
+              className="inline-flex rounded-md bg-yellow-50 p-1.5 text-yellow-500 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-600 focus:ring-offset-2 focus:ring-offset-yellow-50"
+            >
+              <span className="sr-only">閉じる</span>
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### 概要
  認証メール再送信ページの実装と、未認証ユーザーのアクセス制御表示を追加

  ### 変更内容
  - /resend-verificationページを新規作成し、フォームバリデーションと60秒間の連続送信制限機能を実装
  - EmailVerificationBannerコンポーネントを作成し、ホームページで未認証ユーザーに警告バナーを表示
  - ログインページにメール認証エラー時の再送信ページへの導線を追加
  - URLパラメータからのメールアドレス自動入力機能を実装（ログイン→再送信のスムーズな流れ）
  - 認証状態に応じた適切なナビゲーション制御を各ページで実装
  - 成功・エラーメッセージの統一された表示とUXの向上

  ### 動作確認
  - 未認証ユーザーがホームページアクセス時に警告バナーが表示される
  - 再送信ページでメールアドレス入力とバリデーションが正常に動作する
  - 60秒間の連続送信制限が適切に機能し、残り時間が表示される
  - ログイン時のメール認証エラーから再送信ページへスムーズに遷移できる
  - URLパラメータでメールアドレスが自動入力される
  - 認証メール再送信APIが正常に呼び出され、適切なメッセージが表示される



### CloseしたいIssue
Close #107 