### PR TITLE
feat: 認証状態変化に応じたリダイレクトとメッセージ表示機能を実装

### DIFF
--- a/frontend/src/app/growth-records/[id]/page.tsx
+++ b/frontend/src/app/growth-records/[id]/page.tsx
@@ -1,11 +1,25 @@
 'use client'
 
 import { useParams } from 'next/navigation'
+import { useRequireAuthWithRender } from '@/hooks/useRequireAuth'
 import GrowthRecordDetail from '@/components/growth-records/GrowthRecordDetail'
 
 export default function GrowthRecordDetailPage() {
   const params = useParams()
   const id = params.id
+  const { canAccess, isLoading } = useRequireAuthWithRender()
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-600">読み込み中...</div>
+      </div>
+    )
+  }
+
+  if (!canAccess) {
+    return null // リダイレクト中なので何も表示しない
+  }
 
   return (
     <div className="flex justify-center">

--- a/frontend/src/app/growth-records/page.tsx
+++ b/frontend/src/app/growth-records/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useAuth } from '@/contexts/AuthContext'
+import { useRequireAuthWithRender } from '@/hooks/useRequireAuth'
 import GrowthRecordList from '@/components/growth-records/GrowthRecordList'
 
 export default function GrowthRecordsPage() {
-  const { user, isLoading } = useAuth()
+  const { canAccess, isLoading } = useRequireAuthWithRender()
 
   if (isLoading) {
     return (
@@ -14,30 +14,19 @@ export default function GrowthRecordsPage() {
     )
   }
 
-  if (!user) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            ログインが必要です
-          </h2>
-          <p className="text-gray-600">
-            成長記録を表示するにはログインしてください。
-          </p>
-        </div>
-      </div>
-    )
+  if (!canAccess) {
+    return null // リダイレクト中なので何も表示しない
   }
 
   return (
     <div className="flex justify-center" style={{ minWidth: '360px' }}>
       <div className="w-full max-w-2xl px-4 py-6" style={{ minWidth: '360px' }}>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">成長記録</h1>
-        <p className="text-gray-600">あなたの成長記録一覧</p>
-      </div>
-      
-      <GrowthRecordList />
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">成長記録</h1>
+          <p className="text-gray-600">あなたの成長記録一覧</p>
+        </div>
+        
+        <GrowthRecordList />
       </div>
     </div>
   )

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { FlashProvider } from '@/contexts/FlashContext'
 import LayoutWrapper from '@/components/layout/LayoutWrapper'
 import FlashMessages from '@/components/ui/FlashMessages'
 import AutoLogoutModalContainer from '@/components/ui/AutoLogoutModalContainer'
+import RedirectMessageHandler from '@/components/ui/RedirectMessageHandler'
 
 export const metadata = {
   title: 'おうちの畑',
@@ -16,6 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen flex flex-col" style={{ minWidth: '360px' }}>
         <FlashProvider>
           <AuthProvider>
+            <RedirectMessageHandler />
             <LayoutWrapper>
               {children}
             </LayoutWrapper>

--- a/frontend/src/components/ui/RedirectMessageHandler.tsx
+++ b/frontend/src/components/ui/RedirectMessageHandler.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useFlash } from '@/contexts/FlashContext'
+
+/**
+ * 認証リダイレクトメッセージをFlashメッセージに転送するコンポーネント
+ * AuthContextのredirectMessageをFlashContextのaddMessageに移動
+ */
+export default function RedirectMessageHandler() {
+  const { redirectMessage, clearRedirectMessage } = useAuth()
+  const { addMessage } = useFlash()
+
+  useEffect(() => {
+    if (redirectMessage) {
+      // リダイレクトメッセージをフラッシュメッセージとして表示
+      addMessage(redirectMessage, 'info')
+      // AuthContextのメッセージをクリア
+      clearRedirectMessage()
+    }
+  }, [redirectMessage, addMessage, clearRedirectMessage])
+
+  return null // このコンポーネントは何も描画しない
+}

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+
+/**
+ * 認証が必要なページで使用するカスタムフック
+ * 未認証の場合はログイン画面にリダイレクトし、メッセージを表示する
+ */
+export function useRequireAuth() {
+  const router = useRouter()
+  const { isAuthenticated, isLoading, setRedirectMessage } = useAuth()
+
+  useEffect(() => {
+    // ローディング中は何もしない
+    if (isLoading) return
+
+    // 未認証の場合はログイン画面にリダイレクト
+    if (!isAuthenticated) {
+      setRedirectMessage('ログインが必要です')
+      router.push('/login')
+    }
+  }, [isAuthenticated, isLoading, router, setRedirectMessage])
+
+  return {
+    isAuthenticated,
+    isLoading,
+    // 認証済みかつローディング完了の場合のみtrue
+    canAccess: isAuthenticated && !isLoading
+  }
+}
+
+/**
+ * 認証チェック付きでページコンテンツを表示するための状態を返すヘルパーフック
+ * 使用例:
+ * const { canAccess, isLoading } = useRequireAuthWithRender()
+ * if (isLoading) return <Loading />
+ * if (!canAccess) return null
+ * return <YourPageContent />
+ */
+export function useRequireAuthWithRender() {
+  return useRequireAuth()
+}


### PR DESCRIPTION
### 概要
  認証状態の変化（未認証アクセス、ログアウト）に応じた適切なリダイレクトとメッセージ表示機能を実装

  ### 変更内容
  - AuthContextにリダイレクトメッセージ管理機能（redirectMessage、setRedirectMessage、clearRedirectMessage）を追加
  - useRequireAuthカスタムフックを作成し、認証が必要なページでの自動リダイレクト機能を実装
  - ログアウト関数を拡張し、タイムライン（/）へのリダイレクトと「ログアウトしました」メッセージ設定を追加
  - RedirectMessageHandlerコンポーネントを作成し、AuthContextのメッセージを既存のFlashMessagesシステムに転送
  - 成長記録ページ（一覧・詳細）にuseRequireAuth認証チェックを適用し、従来の手動認証チェックから移行
  - app/layout.tsxにRedirectMessageHandlerを統合

  ### 動作確認
  - 未認証状態で `/growth-records` にアクセス → ログイン画面にリダイレクト + 「ログインが必要です」メッセージが右上にtoast表示
  - ログイン状態でログアウト実行 → タイムライン（/）にリダイレクト + 「ログアウトしました」メッセージが右上にtoast表示
  - メッセージは5秒間自動表示され、×ボタンで手動消去も可能
  - TypeScriptエラーなし、既存機能への影響なし

### CloseしたいIssue
Close #71 