### PR TITLE
feat: Active Storageをセットアップして画像添付機能の基盤を構築

### DIFF
--- a/backend/db/migrate/20250812184804_create_active_storage_tables.active_storage.rb
+++ b/backend/db/migrate/20250812184804_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_12_000000) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_12_184804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -142,6 +170,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_12_000000) do
     t.index ["email_verification_token"], name: "index_users_on_email_verification_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "choice_scores", "choices"
   add_foreign_key "choice_scores", "plants"
   add_foreign_key "choices", "questions"


### PR DESCRIPTION
### 概要
  投稿に画像添付機能を実装するため、Active Storageをセットアップして必要なデータベーステーブルを作成

  ### 変更内容
  - rails active_storage:installでActive Storage用マイグレーションファイルを生成
  - active_storage_blobsテーブルを作成（ファイルメタデータ管理用）
  - active_storage_attachmentsテーブルを作成（モデルとファイルの関連付け用）
  - active_storage_variant_recordsテーブルを作成（画像バリアント管理用）
  - データベースマイグレーション実行でテーブル作成完了

  ### 動作確認
  - `docker-compose exec backend rails active_storage:install` で正常にマイグレーションファイル生成
  - `docker-compose exec backend rails db:migrate` で3つのテーブルが正常に作成
  - `rails console`で`ActiveStorage::Blob.all`を実行し、エラーなく空配列`[]`が返されることを確認
  - SQLクエリ（SELECT "active_storage_blobs".* FROM "active_storage_blobs"）が正常に実行されることを確認
  - 画像添付機能実装の基盤準備完了

### CloseしたいIssue
Close #14 