### PR TITLE
feat: 本番環境のActive StorageをAWS S3に設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,6 @@ build-iPhoneSimulator/
 /config/master.key
 .env
 .env.development
+.env.production
 .env.local
 .env*.local

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -33,6 +33,9 @@ gem "dotenv-rails", groups: [ :development, :test ]
 
 gem "jwt"
 
+# AWS S3 for Active Storage
+gem "aws-sdk-s3", require: false
+
 # Cron job management
 gem "whenever", require: false
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -73,6 +73,25 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1146.0)
+    aws-sdk-core (3.229.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.110.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.196.1)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
@@ -106,6 +125,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.12.2)
     jwt (3.0.0)
       base64
@@ -276,6 +296,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -29,8 +29,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files on Amazon S3 (see config/storage.yml for options).
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/backend/config/storage.yml
+++ b/backend/config/storage.yml
@@ -6,13 +6,13 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+# Amazon S3 configuration for Active Storage
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_REGION'] %>
+  bucket: <%= ENV['AWS_S3_BUCKET'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
### 概要
  本番環境でアップロード画像が消えないよう、Active Storageの保存先をAWS S3に設定しました。

  ### 変更内容
  - aws-sdk-s3 gemを追加
  - config/storage.ymlにAmazon S3設定を追加（環境変数参照）
  - production.rbでconfig.active_storage.service = :amazonに変更
  - .env.productionにAWS認証情報を設定
  - .gitignoreに.env.productionを追加してセキュリティ強化

  ### 動作確認
  - AWS S3バケット「ouchi-no-hatake-production」作成済み
  - IAMユーザー「ouchi-no-hatake-user」作成・アクセスキー取得済み
  - .env.productionに実際のAWS認証情報設定済み
  - Rails console確認: ActiveStorage::Blob.service.nameが:amazonを返すことを確認予定

### CloseしたいIssue
Close #72 