### PR TITLE
feat: 投稿に画像アップロード機能を実装

### DIFF
--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -46,6 +46,13 @@ class Api::V1::PostsController < ApplicationController
         }
       end
 
+      # 画像URLを追加
+      if post.images.attached?
+        post_data[:images] = post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+      else
+        post_data[:images] = []
+      end
+
       post_data
     end
 
@@ -111,6 +118,13 @@ class Api::V1::PostsController < ApplicationController
           }
         end
 
+        # 画像URLを追加
+        if @post.images.attached?
+          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+        else
+          post_response[:images] = []
+        end
+
         render json: { post: post_response }, status: :created
       else
         render json: {
@@ -167,6 +181,13 @@ class Api::V1::PostsController < ApplicationController
           }
         end
 
+        # 画像URLを追加
+        if @post.images.attached?
+          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+        else
+          post_response[:images] = []
+        end
+
         render json: { post: post_response }
       else
         render json: {
@@ -211,6 +232,6 @@ class Api::V1::PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :post_type)
+    params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :post_type, images: [])
   end
 end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -3,6 +3,8 @@ class Post < ApplicationRecord
   belongs_to :growth_record, optional: true
   belongs_to :category, optional: true
 
+  has_many_attached :images
+
   validates :content, presence: true
   validates :post_type, presence: true
 


### PR DESCRIPTION
### 概要
  Rails API側でActive Storageを用いた画像アップロード処理と、投稿との紐付けを実装しました。

  ### 変更内容
  - Postモデルにhas_many_attached :imagesを追加
  - Posts APIコントローラーのstrong parametersにimages: []を追加
  - JSONレスポンス（index/create/update）に画像URL配列を追加
  - 画像が添付されていない場合は空配列を返すよう実装

  ### 動作確認
  - API経由で画像付き投稿が作成できることを確認予定
  - 投稿一覧・詳細で画像URLが正しく取得できることを確認予定
  - Active Storageとの連携が正常に動作することを確認予定

### CloseしたいIssue
Close #29 