### PR TITLE
feat: JPEG/PNG形式バリデーションとタイムライン画像表示機能を実装

### DIFF
--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -213,6 +213,15 @@ export default function CreatePostModal({
         return
       }
       
+      // JPEG/PNG形式をチェック
+      const invalidTypeFiles = fileArray.filter(file => 
+        !['image/jpeg', 'image/png'].includes(file.type)
+      )
+      if (invalidTypeFiles.length > 0) {
+        setImageError('JPEG（.jpg）またはPNG（.png）形式の画像のみアップロードできます')
+        return
+      }
+      
       // 既存の画像に新しい画像を追加
       const newSelectedImages = [...selectedImages, ...fileArray]
       setSelectedImages(newSelectedImages)

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -12,6 +12,7 @@ interface Post {
   content: string
   post_type: 'growth_record_post' | 'general_post'
   created_at: string
+  images?: string[]
   user: {
     id: number
     name: string

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -9,6 +9,7 @@ interface TimelinePostProps {
     content: string
     post_type: 'growth_record_post' | 'general_post'
     created_at: string
+    images?: string[]
     user: {
       id: number
       name: string
@@ -107,6 +108,27 @@ export default function TimelinePost({ post }: TimelinePostProps) {
           {post.content}
         </p>
       </div>
+
+      {/* 投稿画像 */}
+      {post.images && post.images.length > 0 && (
+        <div className="mb-4">
+          <div className={`grid gap-2 ${
+            post.images.length === 1 ? 'grid-cols-1' :
+            post.images.length === 2 ? 'grid-cols-2' :
+            'grid-cols-2 md:grid-cols-3'
+          }`}>
+            {post.images.map((imageUrl, index) => (
+              <div key={index} className="relative">
+                <img
+                  src={imageUrl}
+                  alt={`投稿画像 ${index + 1}`}
+                  className="w-full h-48 object-cover rounded-md border border-gray-200"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
 
       {/* アクションボタン */}


### PR DESCRIPTION
### 概要
  JPEG/PNG以外の画像を選択できないようバリデーションを追加し、投稿画像をタイムラインに表示する機能を実装しました。

  ### 変更内容
  - CreatePostModalにJPEG/PNG形式のMIMEタイプバリデーション機能を追加
  - 不正ファイル形式選択時の分かりやすいエラーメッセージ表示を実装
  - Timeline/TimelinePostコンポーネントの型定義にimages配列を追加
  - タイムライン投稿での画像表示機能を実装（レスポンシブグリッド対応）
  - 画像枚数に応じた自動レイアウト調整（1枚、2枚、3枚以上）

  ### 動作確認
  - JPEG/PNG以外のファイル選択時にエラーメッセージが表示されることを確認予定
  - 投稿作成後にタイムラインで画像が正しく表示されることを確認予定
  - レスポンシブデザインで画像グリッドが適切に表示されることを確認予定
  - バリデーションによって不正ファイルの送信が防止されることを確認予定

### CloseしたいIssue
Close #132 