### PR TITLE
feat: 画像アップロードのセキュリティ強化を実装

### DIFF
--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -5,6 +5,9 @@ class Post < ApplicationRecord
 
   has_many_attached :images
 
+  # 画像のバリデーション
+  validate :validate_images
+
   validates :content, presence: true
   validates :post_type, presence: true
 
@@ -16,4 +19,36 @@ class Post < ApplicationRecord
   scope :timeline, -> { includes(:user, :category, growth_record: [ :plant ]).order(created_at: :desc) }
   scope :growth_record_posts, -> { where(post_type: :growth_record_post) }
   scope :general_posts, -> { where(post_type: :general_post) }
+
+  private
+
+  def validate_images
+    return unless images.attached?
+
+    # 枚数制限
+    if images.count > 6
+      errors.add(:images, '画像は最大6枚まで添付できます')
+    end
+
+    images.each_with_index do |image, index|
+      # ファイルサイズ制限（10MB）
+      if image.blob.byte_size > 10.megabytes
+        errors.add(:images, "画像#{index + 1}: ファイルサイズは10MB以下にしてください")
+      end
+
+      # Content-Type検証
+      unless ['image/jpeg', 'image/png'].include?(image.blob.content_type)
+        errors.add(:images, "画像#{index + 1}: JPEG（.jpg）またはPNG（.png）形式のみ対応しています")
+      end
+
+      # ファイル名と拡張子の検証
+      filename = image.blob.filename.to_s.downcase
+      content_type = image.blob.content_type
+
+      if (filename.end_with?('.jpg', '.jpeg') && content_type != 'image/jpeg') ||
+         (filename.end_with?('.png') && content_type != 'image/png')
+        errors.add(:images, "画像#{index + 1}: ファイル名とファイル形式が一致しません")
+      end
+    end
+  end
 end

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -222,6 +222,28 @@ export default function CreatePostModal({
         return
       }
       
+      // ファイル拡張子とMIMEタイプの整合性をチェック
+      const mismatchFiles = fileArray.filter(file => {
+        const fileName = file.name.toLowerCase()
+        const fileType = file.type
+        
+        // JPEG拡張子の場合
+        if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) {
+          return fileType !== 'image/jpeg'
+        }
+        // PNG拡張子の場合
+        if (fileName.endsWith('.png')) {
+          return fileType !== 'image/png'
+        }
+        
+        return true // その他の拡張子は不正
+      })
+      
+      if (mismatchFiles.length > 0) {
+        setImageError('ファイルの拡張子とファイル形式が一致しません。悪意のあるファイルの可能性があります')
+        return
+      }
+      
       // 既存の画像に新しい画像を追加
       const newSelectedImages = [...selectedImages, ...fileArray]
       setSelectedImages(newSelectedImages)


### PR DESCRIPTION
### 概要
  画像アップロード機能にセキュリティ対策を実装し、悪意のあるファイルやサポート外ファイルの送信を防止しました。

  ### 変更内容
  - CreatePostModalにファイル拡張子とMIMEタイプの厳密チェック機能を追加
  - 拡張子偽装・MIMEタイプ偽装検出時のセキュリティエラーメッセージ表示を実装
  - Postモデルにサーバー側画像バリデーション機能（validate_images）を実装
  - 枚数制限（6枚）・ファイルサイズ制限（10MB）・Content-Type検証を追加
  - ファイル名と拡張子の整合性チェック機能をサーバー側に実装
  - クライアント側バイパス攻撃を防止するサーバー側検証を強化

  ### 動作確認
  - 拡張子とMIMEタイプが不一致のファイル選択時にエラーメッセージが表示されることを確認予定
  - サーバー側で不正ファイルが拒否され適切なエラーが返されることを確認予定
  - クライアント側をバイパスした直接API攻撃が防止されることを確認予定
  - 正常なJPEG/PNGファイルは問題なくアップロードできることを確認予定

### CloseしたいIssue
Close #177 