### PR TITLE
feat: 認証期限を6ヶ月に統一しアクティビティベース長期認証を実現

### DIFF
--- a/backend/app/controllers/api/v1/auth_controller.rb
+++ b/backend/app/controllers/api/v1/auth_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::AuthController < ApplicationController
       # サーバーサイドでCookieをセット
       cookies[:auth_token] = {
         value: token,
-        expires: 7.days.from_now,
+        expires: 6.months.from_now,
         path: "/",
         same_site: :none,   # ← クロスオリジンの場合は :none
         secure: true,       # ← https環境なら true、ローカルhttpなら false

--- a/backend/app/services/json_web_token.rb
+++ b/backend/app/services/json_web_token.rb
@@ -2,7 +2,7 @@ class JsonWebToken
   SECRET_KEY = Rails.application.credentials.secret_key_base.to_s
 
   # トークン発行
-  def self.encode(payload, exp = 24.hours.from_now)
+  def self.encode(payload, exp = 6.months.from_now)
     payload[:exp] = exp.to_i
     payload[:jti] = SecureRandom.uuid
     JWT.encode(payload, SECRET_KEY)

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -40,7 +40,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 // Cookie操作のヘルパー関数
-const setCookie = (name: string, value: string, days: number = 7) => {
+const setCookie = (name: string, value: string, days: number = 180) => {
   const expires = new Date()
   expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000)
   const cookieString = `${name}=${value}; expires=${expires.toUTCString()}; path=/; secure=true; samesite=none`


### PR DESCRIPTION
### 概要
  <!-- このPRで何を変更したかを簡潔に -->
  認証期限（JWT、Cookie）を6ヶ月に統一し、アクティビティベースの長期認証システムを実現

  ### 変更内容
  <!-- 具体的な変更点を箇条書きで -->
  - **JWT期限**: 24時間 → 6ヶ月に変更（`json_web_token.rb`）
  - **サーバー側Cookie期限**: 7日間 → 6ヶ月に変更（`auth_controller.rb`）
  - **クライアント側Cookie期限**: 7日間 → 180日（6ヶ月）に変更（`AuthContext.tsx`）
  - **期限統一**: 全認証コンポーネントの期限を6ヶ月で一貫性確保

  ### 動作確認
  <!-- スクリーンショットや動作確認の結果 -->
  - [x] JWT期限が6ヶ月に設定されていることを確認
  - [x] サーバー側Cookie期限が6ヶ月に設定されていることを確認
  - [x] クライアント側Cookie期限が180日に設定されていることを確認
  - [x] 既存のアクティビティベース期間リセット機能が正常動作
  - [x] 既存の認証フロー（ログイン/ログアウト）に影響なし

  ### 期待される効果
  - 6ヶ月間ログイン不要での継続利用が可能
  - 頻繁なログアウトによるユーザーストレス解消
  - ユーザー操作時の自動期間リセットにより適切なセキュリティ維持
  - 設計思想「半年間ログイン不要」の完全実現
### CloseしたいIssue
Close #184