### PR TITLE
refactor: API URL環境変数をNEXT_PUBLIC_API_BASE_URLに統一

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import { authenticatedApiCall, setAutoLogoutCallback } from '@/lib/api'
+import { authenticatedApiCall, setAutoLogoutCallback, API_BASE_URL } from '@/lib/api'
 
 // ユーザー情報の型定義
 interface User {
@@ -83,8 +83,7 @@ const deleteCookie = (name: string) => {
 // サーバーから現在のユーザー情報を取得する関数
 const fetchCurrentUser = async (token: string): Promise<User | null> => {
   try {
-    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'
-    const response = await fetch(`${apiBaseUrl}/api/v1/auth/me`, {
+    const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${token}`,
@@ -394,8 +393,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // メール認証確認関数
   const verifyEmail = useCallback(async (token: string): Promise<{ success: boolean; error?: string; expired?: boolean }> => {
     try {
-      const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'
-      const response = await fetch(`${apiBaseUrl}/api/v1/auth/verify-email`, {
+      const response = await fetch(`${API_BASE_URL}/api/v1/auth/verify-email`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -432,8 +430,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // 認証メール再送信関数
   const resendVerification = useCallback(async (email: string): Promise<{ success: boolean; error?: string }> => {
     try {
-      const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'
-      const response = await fetch(`${apiBaseUrl}/api/v1/auth/resend-verification`, {
+      const response = await fetch(`${API_BASE_URL}/api/v1/auth/resend-verification`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,5 @@
 // API設定
-export const API_BASE_URL = process.env.NODE_ENV === 'production' 
-  ? 'https://ouchi-no-hatake.onrender.com'
-  : 'http://localhost:3001'
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'
 
 // API呼び出し用のヘルパー関数
 export const apiCall = async (endpoint: string, options: RequestInit = {}) => {


### PR DESCRIPTION
### 概要
  <!-- このPRで何を変更したかを簡潔に -->
  API URL環境変数をNEXT_PUBLIC_API_BASE_URLに統一し、ハードコードされたURLを排除して設定を一元管理できるようにしました。

  ### 変更内容
  <!-- 具体的な変更点を箇条書きで -->
  - .env.developmentの環境変数名をNEXT_PUBLIC_API_URLからNEXT_PUBLIC_API_BASE_URLに変更
  - .env.productionのURLを古いドメイン（sodateru-backend）から現在のドメイン（ouchi-no-hatake）に更新
  - lib/api.tsでハードコードされたURL分岐を環境変数NEXT_PUBLIC_API_BASE_URL使用に変更
  - AuthContext.tsxの3箇所で直接環境変数にアクセスしていた部分を共通のAPI_BASE_URL使用に統一

  ### 動作確認
  <!-- スクリーンショットや動作確認の結果 -->
  - 開発環境：localhost:3001への接続が正常に動作することを確認
  - 本番環境：https://ouchi-no-hatake.onrender.comへの接続が正常に動作することを確認
  - 環境変数未設定時：フォールバック値（localhost:3001）が正しく適用されることを確認
  - 構文エラー・型エラーがないことを確認

### CloseしたいIssue
Close #186 