### PR TITLE
fix: 画像アップロード機能の完全修正と表示機能実装

### DIFF
--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -48,7 +48,7 @@ class Api::V1::PostsController < ApplicationController
 
       # 画像URLを追加
       if post.images.attached?
-        post_data[:images] = post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+        post_data[:images] = post.images.map { |image| Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) }
       else
         post_data[:images] = []
       end
@@ -82,24 +82,18 @@ class Api::V1::PostsController < ApplicationController
 
   def create
     begin
-      # リクエストの生データをチェックしてmultipart/form-dataかどうか判定
-      raw_body = request.raw_post
       Rails.logger.debug "Content-Type: #{request.content_type}"
-      Rails.logger.debug "Raw body starts with: #{raw_body[0..100]}"
-
-      # 実際のボディ内容でmultipart判定（Content-Typeが誤認識される場合があるため）
-      is_multipart = raw_body.include?("------WebKit") || raw_body.include?("Content-Disposition: form-data")
-
-      if is_multipart
-        Rails.logger.debug "Processing multipart/form-data request (detected from body)"
-        post_attributes = extract_post_params_from_multipart
-      else
-        Rails.logger.debug "Processing regular request"
-        post_attributes = post_params
+      Rails.logger.debug "Request format: #{request.format}"  
+      Rails.logger.debug "Raw Content-Type header: #{request.headers['Content-Type']}"
+      Rails.logger.debug "Request body size: #{request.raw_post.bytesize} bytes"
+      
+      # Content-Typeのミスマッチを検出
+      if request.headers['Content-Type']&.start_with?('multipart/form-data') && request.content_type == 'application/json'
+        Rails.logger.warn "Content-Type mismatch detected: header=#{request.headers['Content-Type']}, parsed=#{request.content_type}"
       end
-
-      Rails.logger.debug "Extracted post attributes: #{post_attributes.inspect}"
-      @post = current_user.posts.build(post_attributes)
+      
+      # 通常のRailsパラメータ処理を使用
+      @post = current_user.posts.build(post_params)
 
       if @post.save
         post_response = {
@@ -137,7 +131,7 @@ class Api::V1::PostsController < ApplicationController
 
         # 画像URLを追加
         if @post.images.attached?
-          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) }
         else
           post_response[:images] = []
         end
@@ -202,7 +196,7 @@ class Api::V1::PostsController < ApplicationController
 
         # 画像URLを追加
         if @post.images.attached?
-          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.url_for(image) }
+          post_response[:images] = @post.images.map { |image| Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) }
         else
           post_response[:images] = []
         end
@@ -250,85 +244,23 @@ class Api::V1::PostsController < ApplicationController
     }, status: :not_found
   end
 
-  def extract_post_params_from_multipart
-    # リクエストボディを直接読み取り
-    request_body = request.raw_post
-    Rails.logger.debug "Raw request body length: #{request_body.length}"
-
-    # multipart/form-dataを手動解析
-    post_attrs = {}
-    images = []
-
-    # 境界を取得（Content-Typeから取得できない場合は実際のボディから抽出）
-    boundary = nil
-    if request.content_type&.include?("boundary=")
-      boundary = request.content_type.match(/boundary=(.+)$/)[1] rescue nil
-    end
-
-    # Content-Typeから境界が取得できない場合、実際のボディから抽出
-    if boundary.nil?
-      if match = request_body.match(/^--(.*?)(?:\r\n|\n)/)
-        boundary = match[1]
-        Rails.logger.debug "Extracted boundary from body: #{boundary}"
-      end
-    end
-
-    return {} unless boundary
-
-    # パートごとに分割して処理
-    parts = request_body.split("--#{boundary}")
-
-    parts.each do |part|
-      next if part.strip.empty? || part.strip == "--"
-
-      # ヘッダー部分とボディ部分を分割
-      header_end = part.index("\r\n\r\n") || part.index("\n\n")
-      next unless header_end
-
-      headers = part[0...header_end]
-      body = part[(header_end + 4)..-1]
-      body = body.chomp("\r\n") if body&.end_with?("\r\n")
-
-      # Content-Dispositionヘッダーから名前を抽出
-      if match = headers.match(/name="post\[([^\]]+)\]"/)
-        field_name = match[1]
-        Rails.logger.debug "Processing field: #{field_name}, value: #{body&.strip}"
-
-        # バイナリデータ（画像など）をスキップ
-        if headers.include?("Content-Type: image/")
-          Rails.logger.debug "Skipping binary image data for field: #{field_name}"
-          next
-        end
-
-        case field_name
-        when "title", "content", "post_type"
-          post_attrs[field_name.to_sym] = body&.strip
-        when "growth_record_id", "category_id"
-          post_attrs[field_name.to_sym] = body.to_i if body.present? && body.strip.present?
-        when "images"
-          # 画像ファイルの場合は今回スキップ
-          Rails.logger.debug "Image field detected, skipping for now"
-        end
-      end
-    end
-
-    post_attrs[:images] = images if images.any?
-    Rails.logger.debug "Extracted post attributes: #{post_attrs.inspect}"
-
-    post_attrs
-  rescue => e
-    Rails.logger.error "Error extracting multipart params: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    {}
-  end
 
   def post_params
     Rails.logger.debug "Available params keys: #{params.keys.inspect}"
-    Rails.logger.debug "Post params: #{params[:post]&.inspect}"
-    params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :post_type, images: [])
+    Rails.logger.debug "Post params keys: #{params[:post]&.keys&.inspect}"
+    Rails.logger.debug "Images present: #{params[:post]&.[](:images).present?}"
+    if params[:post]&.[](:images).present?
+      Rails.logger.debug "Images count: #{params[:post][:images].size}"
+    end
+    
+    permitted_params = params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :post_type, images: [])
+    permitted_params_safe = permitted_params.except(:images)
+    Rails.logger.debug "Permitted params (without images): #{permitted_params_safe.inspect}"
+    Rails.logger.debug "Images permitted: #{permitted_params[:images].present?}"
+    permitted_params
   rescue ActionController::ParameterMissing => e
     Rails.logger.error "Parameter missing error: #{e.message}"
-    Rails.logger.error "All params: #{params.inspect}"
+    Rails.logger.error "Available params keys: #{params.keys.inspect}"
     raise e
   end
 end

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -83,15 +83,15 @@ class Api::V1::PostsController < ApplicationController
   def create
     begin
       Rails.logger.debug "Content-Type: #{request.content_type}"
-      Rails.logger.debug "Request format: #{request.format}"  
+      Rails.logger.debug "Request format: #{request.format}"
       Rails.logger.debug "Raw Content-Type header: #{request.headers['Content-Type']}"
       Rails.logger.debug "Request body size: #{request.raw_post.bytesize} bytes"
-      
+
       # Content-Typeのミスマッチを検出
-      if request.headers['Content-Type']&.start_with?('multipart/form-data') && request.content_type == 'application/json'
+      if request.headers["Content-Type"]&.start_with?("multipart/form-data") && request.content_type == "application/json"
         Rails.logger.warn "Content-Type mismatch detected: header=#{request.headers['Content-Type']}, parsed=#{request.content_type}"
       end
-      
+
       # 通常のRailsパラメータ処理を使用
       @post = current_user.posts.build(post_params)
 
@@ -252,7 +252,7 @@ class Api::V1::PostsController < ApplicationController
     if params[:post]&.[](:images).present?
       Rails.logger.debug "Images count: #{params[:post][:images].size}"
     end
-    
+
     permitted_params = params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :post_type, images: [])
     permitted_params_safe = permitted_params.except(:images)
     Rails.logger.debug "Permitted params (without images): #{permitted_params_safe.inspect}"

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -26,8 +26,8 @@ class Post < ApplicationRecord
     return unless images.attached?
 
     # 枚数制限
-    if images.count > 6
-      errors.add(:images, "画像は最大6枚まで添付できます")
+    if images.count > 4
+      errors.add(:images, "画像は最大4枚まで添付できます")
     end
 
     images.each_with_index do |image, index|

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -89,10 +89,10 @@ Rails.application.configure do
   config.hosts << "backend"
   config.hosts << "backend:3000"
   config.hosts << "localhost"
-  
+
   # ログでバイナリデータの出力を抑制
   config.log_level = :debug
-  
+
   # カスタムログフィルター - バイナリデータをログから除外
   Rails.application.config.filter_parameters += [
     :password, :password_confirmation, :images, :image, :avatar, :file, :attachment

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Active Storage URL生成用の設定
+  Rails.application.routes.default_url_options = { host: "localhost", port: 3001 }
+
   config.action_mailer.smtp_settings = {
     user_name: "apikey",
     password: ENV["SENDGRID_API_KEY"],
@@ -86,4 +89,12 @@ Rails.application.configure do
   config.hosts << "backend"
   config.hosts << "backend:3000"
   config.hosts << "localhost"
+  
+  # ログでバイナリデータの出力を抑制
+  config.log_level = :debug
+  
+  # カスタムログフィルター - バイナリデータをログから除外
+  Rails.application.config.filter_parameters += [
+    :password, :password_confirmation, :images, :image, :avatar, :file, :attachment
+  ]
 end

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -29,7 +29,7 @@ const CATEGORIES = [
 // 画像アップロード制限
 const IMAGE_UPLOAD_LIMITS = {
   MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB
-  MAX_FILE_COUNT: 6
+  MAX_FILE_COUNT: 4
 }
 
 interface PostData {

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@/contexts/AuthContext'
 import { useState } from 'react'
 import Link from 'next/link'
+import { API_BASE_URL } from '@/lib/api'
 
 interface TimelinePostProps {
   post: {
@@ -112,17 +113,20 @@ export default function TimelinePost({ post }: TimelinePostProps) {
       {/* 投稿画像 */}
       {post.images && post.images.length > 0 && (
         <div className="mb-4">
-          <div className={`grid gap-2 ${
+          <div className={`grid gap-2 max-h-80 overflow-hidden ${
             post.images.length === 1 ? 'grid-cols-1' :
-            post.images.length === 2 ? 'grid-cols-2' :
-            'grid-cols-2 md:grid-cols-3'
+            'grid-cols-2'
           }`}>
             {post.images.map((imageUrl, index) => (
               <div key={index} className="relative">
                 <img
-                  src={imageUrl}
+                  src={`${API_BASE_URL}${imageUrl}`}
                   alt={`投稿画像 ${index + 1}`}
-                  className="w-full h-48 object-cover rounded-md border border-gray-200"
+                  className={`w-full rounded-md border border-gray-200 ${
+                    post.images?.length === 1 
+                      ? 'max-h-80 object-contain' 
+                      : 'h-36 object-cover'
+                  }`}
                 />
               </div>
             ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,8 +5,11 @@ export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://loca
 export const apiCall = async (endpoint: string, options: RequestInit = {}) => {
   const url = `${API_BASE_URL}${endpoint}`
 
-  const defaultHeaders = {
-    'Content-Type': 'application/json',
+  const defaultHeaders: Record<string, string> = {}
+
+  // FormDataの場合はContent-Typeを設定しない（ブラウザに自動設定させる）
+  if (!(options.body instanceof FormData)) {
+    defaultHeaders['Content-Type'] = 'application/json'
   }
 
   return fetch(url, {
@@ -31,9 +34,13 @@ export const setAutoLogoutCallback = (callback: () => void) => {
 export const authenticatedApiCall = async (endpoint: string, token: string, options: RequestInit = {}) => {
   const url = `${API_BASE_URL}${endpoint}`
 
-  const defaultHeaders = {
-    'Content-Type': 'application/json',
+  const defaultHeaders: Record<string, string> = {
     'Authorization': `Bearer ${token}`,
+  }
+
+  // FormDataの場合はContent-Typeを設定しない（ブラウザに自動設定させる）
+  if (!(options.body instanceof FormData)) {
+    defaultHeaders['Content-Type'] = 'application/json'
   }
 
   const response = await fetch(url, {


### PR DESCRIPTION
### 概要
  <!-- このPRで何を変更したかを簡潔に -->
  POST /api/v1/postsの画像アップロード時に発生していたmultipart/form-data解析エラーを修正し、画像投稿機能を完全実装しました。ログの文字化けも解消され、投稿された画像がタイムラインで正常に表示されるようになります。

  ### 変更内容
  <!-- 具体的な変更点を箇条書きで -->
  - **multipart/form-data解析エラー修正**: 手動解析ロジックを削除し、通常のRailsパラメータ処理に統一
  - **Content-Typeヘッダー処理改善**: フロントエンドでFormData検出時にContent-Typeヘッダー設定をスキップ
  - **ログ文字化け問題解消**: バイナリデータのログ出力を除外するフィルター設定を追加
  - **Active Storage URL生成修正**: `url_for`から`rails_blob_path`に変更してURL生成エラーを解決
  - **画像表示機能実装**: API_BASE_URLとの結合処理でフロントエンドでの画像表示を実現
  - **画像制限調整**: アップロード上限を6枚から4枚に変更
  - **レスポンシブ表示対応**: 1枚は全体表示、複数枚は田の字配置（2x2グリッド）で統一

  ### 動作確認
  <!-- スクリーンショットや動作確認の結果 -->
  - [x] 画像付き投稿の作成が正常に動作することを確認
  - [x] 投稿された画像がタイムラインで表示されることを確認
  - [x] ログに文字化けが発生しないことを確認
  - [x] 4枚までの画像アップロード制限が機能することを確認
  - [x] 田の字配置（2x2グリッド）での表示が適切に動作することを確認
  - [x] レスポンシブデザインでの表示が問題ないことを確認