### PR TITLE
feat: 画像モーダル表示機能を実装

### DIFF
--- a/frontend/src/components/layout/LayoutWrapper.tsx
+++ b/frontend/src/components/layout/LayoutWrapper.tsx
@@ -2,17 +2,20 @@
 
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
+import { ImageModalProvider, useImageModal } from '@/contexts/ImageModalContext'
 import PublicHeader from './PublicHeader'
 import PublicFooter from './PublicFooter'
 import AuthenticatedHeader from './AuthenticatedHeader'
 import AuthenticatedFooter from './AuthenticatedFooter'
+import ImageModal from '@/components/ui/ImageModal'
 
 interface LayoutWrapperProps {
   children: React.ReactNode
 }
 
-export default function LayoutWrapper({ children }: LayoutWrapperProps) {
+function LayoutWrapperContent({ children }: LayoutWrapperProps) {
   const { user, isLoading, isAuthenticated } = useAuth()
+  const { modalState, closeModal, navigateImage } = useImageModal()
   
   console.log('LayoutWrapper - user:', user, 'isLoading:', isLoading, 'isAuthenticated:', isAuthenticated)
   
@@ -50,6 +53,14 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
           {children}
         </main>
         <AuthenticatedFooter />
+        <ImageModal
+          images={modalState.images}
+          currentIndex={modalState.currentIndex}
+          isOpen={modalState.isOpen}
+          onClose={closeModal}
+          onNavigate={navigateImage}
+          title={modalState.title}
+        />
       </>
     )
   }
@@ -63,6 +74,22 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
         {children}
       </main>
       <PublicFooter />
+      <ImageModal
+        images={modalState.images}
+        currentIndex={modalState.currentIndex}
+        isOpen={modalState.isOpen}
+        onClose={closeModal}
+        onNavigate={navigateImage}
+        title={modalState.title}
+      />
     </>
+  )
+}
+
+export default function LayoutWrapper({ children }: LayoutWrapperProps) {
+  return (
+    <ImageModalProvider>
+      <LayoutWrapperContent>{children}</LayoutWrapperContent>
+    </ImageModalProvider>
   )
 }

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@/contexts/AuthContext'
+import { useImageModal } from '@/contexts/ImageModalContext'
 import { useState } from 'react'
 import Link from 'next/link'
 import { API_BASE_URL } from '@/lib/api'
@@ -32,11 +33,19 @@ interface TimelinePostProps {
 
 export default function TimelinePost({ post }: TimelinePostProps) {
   const { isAuthenticated } = useAuth()
+  const { openModal } = useImageModal()
   const [showLoginModal, setShowLoginModal] = useState(false)
 
   const handleInteractionClick = () => {
     if (!isAuthenticated) {
       setShowLoginModal(true)
+    }
+  }
+
+  const handleImageClick = (imageIndex: number) => {
+    if (post.images && post.images.length > 0) {
+      const fullImageUrls = post.images.map(imageUrl => `${API_BASE_URL}${imageUrl}`)
+      openModal(fullImageUrls, imageIndex, post.title || `${post.user.name}の投稿`)
     }
   }
 
@@ -118,15 +127,16 @@ export default function TimelinePost({ post }: TimelinePostProps) {
             'grid-cols-2'
           }`}>
             {post.images.map((imageUrl, index) => (
-              <div key={index} className="relative">
+              <div key={index} className="relative cursor-pointer">
                 <img
                   src={`${API_BASE_URL}${imageUrl}`}
                   alt={`投稿画像 ${index + 1}`}
-                  className={`w-full rounded-md border border-gray-200 ${
+                  className={`w-full rounded-md border border-gray-200 transition-opacity hover:opacity-90 ${
                     post.images?.length === 1 
                       ? 'max-h-80 object-contain' 
                       : 'h-36 object-cover'
                   }`}
+                  onClick={() => handleImageClick(index)}
                 />
               </div>
             ))}

--- a/frontend/src/components/ui/ImageModal.tsx
+++ b/frontend/src/components/ui/ImageModal.tsx
@@ -66,8 +66,8 @@ export default function ImageModal({
       onClick={onClose}
     >
       <div className="relative w-full h-full max-w-7xl mx-auto">
-        {/* モバイル版: フルスクリーン表示 */}
-        <div className="md:hidden flex items-center justify-center h-full p-4">
+        {/* PC・モバイル共通: フルスクリーン表示 */}
+        <div className="flex items-center justify-center h-full p-4 md:p-8">
           <img
             src={currentImage}
             alt={title || `画像 ${currentIndex + 1}`}
@@ -76,51 +76,29 @@ export default function ImageModal({
           />
         </div>
 
-        {/* PC版: 左側画像 + 右側情報 */}
-        <div className="hidden md:flex h-full">
-          {/* 左側: 画像表示エリア */}
-          <div className="flex-1 flex items-center justify-center p-8">
-            <img
-              src={currentImage}
-              alt={title || `画像 ${currentIndex + 1}`}
-              className="max-w-full max-h-full object-contain"
-              onClick={(e) => e.stopPropagation()}
-            />
-          </div>
-
-          {/* 右側: 情報表示エリア */}
-          <div className="w-80 bg-white p-6 flex flex-col" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-gray-900">
-                {title || '画像詳細'}
-              </h2>
-              <button
-                onClick={onClose}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            
-            {images.length > 1 && (
-              <div className="text-sm text-gray-500 mb-4">
-                {currentIndex + 1} / {images.length}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* 閉じるボタン (モバイル版) */}
+        {/* 閉じるボタン */}
         <button
           onClick={onClose}
-          className="md:hidden absolute top-4 right-4 p-2 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
+          className="absolute top-4 right-4 p-2 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
+
+        {/* 画像情報オーバーレイ */}
+        {(title || images.length > 1) && (
+          <div className="absolute top-4 left-4 bg-black bg-opacity-50 text-white px-3 py-2 rounded-md">
+            {title && (
+              <div className="font-medium text-sm mb-1">{title}</div>
+            )}
+            {images.length > 1 && (
+              <div className="text-xs text-gray-300">
+                {currentIndex + 1} / {images.length}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* ナビゲーションボタン */}
         {images.length > 1 && (
@@ -141,7 +119,7 @@ export default function ImageModal({
                 e.stopPropagation()
                 onNavigate('next')
               }}
-              className="absolute right-4 md:right-[21rem] top-1/2 transform -translate-y-1/2 p-3 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
+              className="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -152,7 +130,7 @@ export default function ImageModal({
 
         {/* インジケーター */}
         {images.length > 1 && (
-          <div className="absolute bottom-4 left-1/2 md:left-1/4 transform -translate-x-1/2 flex space-x-2">
+          <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
             {images.map((_, index) => (
               <button
                 key={index}
@@ -166,7 +144,7 @@ export default function ImageModal({
                 }}
                 className={`w-3 h-3 rounded-full transition-colors ${
                   index === currentIndex 
-                    ? 'bg-white' 
+                    ? 'bg-green-500' 
                     : 'bg-white bg-opacity-50 hover:bg-opacity-75'
                 }`}
               />

--- a/frontend/src/components/ui/ImageModal.tsx
+++ b/frontend/src/components/ui/ImageModal.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface ImageModalProps {
+  images: string[]
+  currentIndex: number
+  isOpen: boolean
+  onClose: () => void
+  onNavigate: (direction: 'prev' | 'next') => void
+  title?: string
+}
+
+export default function ImageModal({ 
+  images, 
+  currentIndex, 
+  isOpen, 
+  onClose, 
+  onNavigate,
+  title 
+}: ImageModalProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen) return
+      
+      switch (event.key) {
+        case 'Escape':
+          onClose()
+          break
+        case 'ArrowLeft':
+          if (images.length > 1) {
+            onNavigate('prev')
+          }
+          break
+        case 'ArrowRight':
+          if (images.length > 1) {
+            onNavigate('next')
+          }
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, images.length, onClose, onNavigate])
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'unset'
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset'
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const currentImage = images[currentIndex]
+
+  return (
+    <div 
+      className="fixed inset-0 z-50 bg-black bg-opacity-90 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div className="relative w-full h-full max-w-7xl mx-auto">
+        {/* モバイル版: フルスクリーン表示 */}
+        <div className="md:hidden flex items-center justify-center h-full p-4">
+          <img
+            src={currentImage}
+            alt={title || `画像 ${currentIndex + 1}`}
+            className="max-w-full max-h-full object-contain"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+
+        {/* PC版: 左側画像 + 右側情報 */}
+        <div className="hidden md:flex h-full">
+          {/* 左側: 画像表示エリア */}
+          <div className="flex-1 flex items-center justify-center p-8">
+            <img
+              src={currentImage}
+              alt={title || `画像 ${currentIndex + 1}`}
+              className="max-w-full max-h-full object-contain"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+
+          {/* 右側: 情報表示エリア */}
+          <div className="w-80 bg-white p-6 flex flex-col" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900">
+                {title || '画像詳細'}
+              </h2>
+              <button
+                onClick={onClose}
+                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            
+            {images.length > 1 && (
+              <div className="text-sm text-gray-500 mb-4">
+                {currentIndex + 1} / {images.length}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 閉じるボタン (モバイル版) */}
+        <button
+          onClick={onClose}
+          className="md:hidden absolute top-4 right-4 p-2 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        {/* ナビゲーションボタン */}
+        {images.length > 1 && (
+          <>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onNavigate('prev')
+              }}
+              className="absolute left-4 top-1/2 transform -translate-y-1/2 p-3 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onNavigate('next')
+              }}
+              className="absolute right-4 md:right-[21rem] top-1/2 transform -translate-y-1/2 p-3 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-70 transition-colors"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </>
+        )}
+
+        {/* インジケーター */}
+        {images.length > 1 && (
+          <div className="absolute bottom-4 left-1/2 md:left-1/4 transform -translate-x-1/2 flex space-x-2">
+            {images.map((_, index) => (
+              <button
+                key={index}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  const direction = index > currentIndex ? 'next' : 'prev'
+                  const steps = Math.abs(index - currentIndex)
+                  for (let i = 0; i < steps; i++) {
+                    setTimeout(() => onNavigate(direction), i * 100)
+                  }
+                }}
+                className={`w-3 h-3 rounded-full transition-colors ${
+                  index === currentIndex 
+                    ? 'bg-white' 
+                    : 'bg-white bg-opacity-50 hover:bg-opacity-75'
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/contexts/ImageModalContext.tsx
+++ b/frontend/src/contexts/ImageModalContext.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+
+interface ImageModalState {
+  isOpen: boolean
+  images: string[]
+  currentIndex: number
+  title?: string
+}
+
+interface ImageModalContextType {
+  modalState: ImageModalState
+  openModal: (images: string[], initialIndex?: number, title?: string) => void
+  closeModal: () => void
+  navigateImage: (direction: 'prev' | 'next') => void
+}
+
+const ImageModalContext = createContext<ImageModalContextType | undefined>(undefined)
+
+interface ImageModalProviderProps {
+  children: ReactNode
+}
+
+export function ImageModalProvider({ children }: ImageModalProviderProps) {
+  const [modalState, setModalState] = useState<ImageModalState>({
+    isOpen: false,
+    images: [],
+    currentIndex: 0,
+    title: undefined
+  })
+
+  const openModal = (images: string[], initialIndex = 0, title?: string) => {
+    setModalState({
+      isOpen: true,
+      images,
+      currentIndex: initialIndex,
+      title
+    })
+  }
+
+  const closeModal = () => {
+    setModalState(prev => ({
+      ...prev,
+      isOpen: false
+    }))
+  }
+
+  const navigateImage = (direction: 'prev' | 'next') => {
+    setModalState(prev => {
+      if (!prev.isOpen || prev.images.length <= 1) return prev
+
+      let newIndex = prev.currentIndex
+      if (direction === 'next') {
+        newIndex = (prev.currentIndex + 1) % prev.images.length
+      } else {
+        newIndex = prev.currentIndex === 0 ? prev.images.length - 1 : prev.currentIndex - 1
+      }
+
+      return {
+        ...prev,
+        currentIndex: newIndex
+      }
+    })
+  }
+
+  return (
+    <ImageModalContext.Provider 
+      value={{ 
+        modalState, 
+        openModal, 
+        closeModal, 
+        navigateImage 
+      }}
+    >
+      {children}
+    </ImageModalContext.Provider>
+  )
+}
+
+export function useImageModal() {
+  const context = useContext(ImageModalContext)
+  if (context === undefined) {
+    throw new Error('useImageModal must be used within an ImageModalProvider')
+  }
+  return context
+}


### PR DESCRIPTION
### 概要
  投稿画像をクリック時に拡大モーダル表示する機能を実装しました。PC・モバイル共通でフルスクリーン画像表示とし、汎用的なコンポーネントとして作成して全アプリケーション共通で使用可能です。

  ### 変更内容
  - 汎用ImageModalコンポーネントを`/components/ui/`に作成
  - ImageModalContextでグローバル状態管理を実装
  - LayoutWrapperにImageModalProviderとImageModalを統合
  - TimelinePostの投稿画像にクリックイベントとhover効果を追加
  - PC・モバイル共通でフルスクリーン画像表示を実装
  - タイトルと画像番号を左上オーバーレイで表示
  - ESCキー・背景クリック・右上×ボタンでの閉じる機能
  - 左右矢印キー・ナビゲーションボタン・インジケーターでの画像切り替え機能
  - インジケーターを緑色でアプリテーマに統一

  ### 動作確認
  - [x] 投稿画像をクリックしてモーダルが表示されることを確認
  - [x] PC・モバイル共通でフルスクリーン表示されることを確認
  - [x] ESCキー・背景クリック・×ボタンで閉じることを確認
  - [x] 複数画像の場合に左右ナビゲーションが動作することを確認
  - [x] インジケーターで現在表示中の画像が緑色で分かることを確認
  - [x] レスポンシブデザインが適切に動作することを確認

  ### 関連Issue
  Closes #190