### PR TITLE
feat: 成長記録のrecord_name自動命名機能を実装

### DIFF
--- a/backend/app/services/growth_record_service.rb
+++ b/backend/app/services/growth_record_service.rb
@@ -83,6 +83,11 @@ class GrowthRecordService < ApplicationService
     growth_record = user.growth_records.build(params)
     growth_record.record_number = next_record_number
 
+    # record_name が空の場合、自動生成
+    if params[:record_name].blank?
+      growth_record.record_name = "成長記録#{next_record_number}"
+    end
+
     if growth_record.save
       OpenStruct.new(
         success: true,
@@ -101,6 +106,11 @@ class GrowthRecordService < ApplicationService
 
   # 成長記録更新
   def self.update_growth_record(record, params)
+    # record_name をクリア（空文字列）した場合も自動生成
+    if params.key?(:record_name) && params[:record_name].blank?
+      params = params.merge(record_name: "成長記録#{record.record_number}")
+    end
+
     if record.update(params)
       OpenStruct.new(
         success: true,


### PR DESCRIPTION
## 変更概要
成長記録（GrowthRecord）作成時に `record_name` が未入力の場合、自動的に「成長記録#{record_number}」の形式で命名する機能を実装しました。

ユーザーの入力負担を軽減し、record_number を活用した一貫性のある命名を実現します。

## 種別
- [x] **Feature**: 新機能追加
- [ ] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/growth_record_service.rb](../backend/app/services/growth_record_service.rb) を確認済み
- [x] [backend/app/models/growth_record.rb](../backend/app/models/growth_record.rb) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック

### バックエンド
- [x] Controller は50行以内
- [x] Service層にビジネスロジック配置済み
- [x] ApplicationSerializer でレスポンス統一済み

**実装コード**:
```ruby
# GrowthRecordService.create_growth_record
# record_name が空の場合、自動生成
if params[:record_name].blank?
  growth_record.record_name = "成長記録#{next_record_number}"
end

# GrowthRecordService.update_growth_record
# record_name をクリア（空文字列）した場合も自動生成
if params.key?(:record_name) && params[:record_name].blank?
  params = params.merge(record_name: "成長記録#{record.record_number}")
end
```

---

## セキュリティチェック
- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [x] RuboCop 通過（バックエンド変更時）
- [x] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [x] **バックエンド**: GrowthRecordService に record_name 自動設定ロジック追加
- [ ] **フロントエンド**: なし
- [ ] **データベース**: なし
- [ ] **その他**: なし

### 変更詳細

#### backend/app/services/growth_record_service.rb
1. **create_growth_record メソッド**: 
   - record_name が空の場合、「成長記録#{next_record_number}」を自動設定
   - ユーザーが設定した record_name は上書きしない

2. **update_growth_record メソッド**: 
   - record_name をクリア（空文字列）した場合も自動生成
   - 既存の record_number を使用

## 動作確認

- [x] 主要機能の動作確認完了（record_name 未入力時の自動生成）
- [x] エラーケースの動作確認完了（手動設定時の上書きなし）
- [x] 関連機能の回帰テスト完了（既存の成長記録作成・更新）

## 関連情報

**Issue**: Closes #28

**参考実装**:
- 既存の record_number 自動採番ロジック: [backend/app/services/growth_record_service.rb:79-84](../backend/app/services/growth_record_service.rb#L79-L84)

**仕様**:
- record_name の上書き: **しない** - ユーザーが設定した名前を尊重
- フォーマット: 「成長記録#{record_number}」（例: 成長記録1、成長記録2）
- Service層で実装し、リファクタ成果（責務分離）を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)