### PR TITLE
fix: フォロー後のマイページフォロー数更新問題を修正

### DIFF
--- a/frontend/src/components/users/FollowButton.tsx
+++ b/frontend/src/components/users/FollowButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { apiClient } from '@/services/apiClient'
+import { useAuthContext as useAuth } from '@/contexts/auth'
 
 interface FollowButtonProps {
   userId: number
@@ -12,6 +13,7 @@ interface FollowButtonProps {
 
 export default function FollowButton({ userId, isFollowing, isOwnProfile, onFollowChange }: FollowButtonProps) {
   const [loading, setLoading] = useState(false)
+  const { refreshUser } = useAuth()
 
   // 自分のプロフィールの場合は非表示
   if (isOwnProfile) {
@@ -35,6 +37,7 @@ export default function FollowButton({ userId, isFollowing, isOwnProfile, onFoll
 
       if (result.success) {
         onFollowChange()
+        await refreshUser()
       } else {
         alert(result.error.message)
       }

--- a/frontend/src/contexts/auth/AuthContext.tsx
+++ b/frontend/src/contexts/auth/AuthContext.tsx
@@ -26,6 +26,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
+  // ユーザー情報を再取得する関数
+  const refreshUser = async () => {
+    const currentToken = token || localStorage.getItem('auth_token')
+    if (!currentToken) return
+
+    const freshUser = await fetchCurrentUser(currentToken)
+    if (freshUser) {
+      setUser(freshUser)
+      localStorage.setItem('auth_user', JSON.stringify(freshUser))
+    }
+  }
+
   // ページ読み込み時にlocalStorageからトークンを復元
   useEffect(() => {
     const initializeAuth = async () => {
@@ -120,6 +132,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     token,
     isAuthenticated: !!user && !!token,
     isLoading,
+    refreshUser,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -57,6 +57,7 @@ export interface AuthState {
   token: string | null
   isAuthenticated: boolean
   isLoading: boolean
+  refreshUser: () => Promise<void>
 }
 
 // 認証アクションの型定義


### PR DESCRIPTION
## 変更概要
他ユーザーをフォローした後、マイページに戻ってもフォロー数が更新されない問題を修正しました。AuthContextにユーザー情報を再取得する`refreshUser()`関数を追加し、フォロー成功後に自動的に呼び出すことで、マイページのフォロー数がリアルタイムで更新されるようになります。

## 種別
<!-- 該当する種別にチェック -->
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [ ] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [ ] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [x] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [x] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [ ] Controller は50行以内
- [ ] Service層にビジネスロジック配置済み
- [ ] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [x] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [x] ApiResult<T> で型安全なエラーハンドリング実装済み
- [x] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [ ] RuboCop 通過（バックエンド変更時）
- [x] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [ ] **バックエンド**: 変更なし
- [x] **フロントエンド**: AuthContextにrefreshUser()関数追加、FollowButtonでフォロー成功後に呼び出し
- [ ] **データベース**: 変更なし
- [ ] **その他**: 設定・ドキュメント等

## 動作確認

- [x] 主要機能の動作確認完了
- [x] エラーケースの動作確認完了
- [x] 関連機能の回帰テスト完了

## 関連情報
<!-- 関連Issue、参考資料、注意事項等 -->

Closes #279