### PR TITLE
feat: Google Analytics 4導入によるアクセス解析機能追加

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import LayoutWrapper from '@/components/layout/LayoutWrapper'
 import FlashMessages from '@/components/ui/FlashMessages'
 import AutoLogoutModalContainer from '@/components/ui/AutoLogoutModalContainer'
 import RedirectMessageHandler from '@/components/ui/RedirectMessageHandler'
+import GoogleAnalytics from '@/components/analytics/GoogleAnalytics'
 
 import type { Metadata, Viewport } from 'next'
 
@@ -40,6 +41,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
+      <head>
+        <GoogleAnalytics />
+      </head>
       <body className="min-h-screen flex flex-col" style={{ minWidth: '360px' }}>
         <FlashProvider>
           <AuthProvider>

--- a/frontend/src/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/src/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,27 @@
+import Script from 'next/script'
+
+export default function GoogleAnalytics() {
+  const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+
+  // 開発環境またはmeasurementIdが設定されていない場合は何も表示しない
+  if (process.env.NODE_ENV === 'development' || !measurementId) {
+    return null
+  }
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${measurementId}');
+        `}
+      </Script>
+    </>
+  )
+}


### PR DESCRIPTION
## 変更概要
ポートフォリオのアクセス数やアクティブユーザー数を測定するため、Google Analytics 4（GA4）を導入しました。
これにより、リリース後のユーザー動向を把握し、サービス改善に活用できます。

## 種別
- [x] **Feature**: 新機能追加
- [ ] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [x] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [x] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [x] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック

### バックエンド
- [x] Controller は50行以内（該当なし）
- [x] Service層にビジネスロジック配置済み（該当なし）
- [x] ApplicationSerializer でレスポンス統一済み（該当なし）

### フロントエンド
- [x] apiClient.post/get/put/delete 使用（該当なし - 外部サービス連携）
- [x] ApiResult<T> で型安全なエラーハンドリング実装済み（該当なし）
- [x] types/ に型定義追加済み（該当なし）

---

## セキュリティチェック

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [x] RuboCop 通過（バックエンド変更時）
- [x] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [ ] **バックエンド**: なし
- [x] **フロントエンド**: 
  - GoogleAnalyticsコンポーネントを作成（frontend/src/components/analytics/GoogleAnalytics.tsx）
  - layout.tsxのheadタグ内にGA4スクリプトを追加
  - 環境変数NEXT_PUBLIC_GA_MEASUREMENT_IDで測定IDを管理
  - 開発環境（NODE_ENV=development）ではGA4を無効化
  - Next.js Script コンポーネントのstrategy="afterInteractive"を使用してパフォーマンス最適化
- [ ] **データベース**: なし
- [ ] **その他**: なし

## 動作確認

- [x] 主要機能の動作確認完了
  - 開発環境でGA4スクリプトが読み込まれないことを確認
  - ビルドが正常に完了することを確認
- [ ] エラーケースの動作確認完了（該当なし）
- [x] 関連機能の回帰テスト完了

## デプロイ後の確認事項

### Vercel環境変数設定（デプロイ時に必須）
1. Vercelダッシュボードにアクセス
2. プロジェクト設定 → Environment Variables
3. 以下を追加:
   - Key: `NEXT_PUBLIC_GA_MEASUREMENT_ID`
   - Value: `G-NTM4ZNNV7C`
   - Environment: `Production`

### 本番環境での動作確認手順
1. Vercelにデプロイ後、本番環境のURLにアクセス
2. ブラウザの開発者ツール → Networkタブを確認
3. `gtag/js` へのリクエストがあることを確認
4. Google Analyticsの管理画面 → リアルタイムレポートを確認
5. アクセスが記録されていることを確認

## 関連情報

Closes #305

## 補足
- 測定ID（G-NTM4ZNNV7C）は`.env.production`に記載されていますが、このファイルは`.gitignore`で除外されているためリポジトリにはコミットされていません
- Vercel環境変数に手動で設定する必要があります