### PR TITLE
fix: PasswordResetTokenのRuby 3.4互換性問題を修正

### DIFF
--- a/backend/app/models/password_reset_token.rb
+++ b/backend/app/models/password_reset_token.rb
@@ -35,7 +35,7 @@ class PasswordResetToken < ApplicationRecord
   end
 
   # トークンが有効かどうかを確認
-  def valid?
+  def valid_token?
     !expired?
   end
 


### PR DESCRIPTION
## 変更概要
Ruby 3.4でパスワードリセット機能が500エラーになる問題を修正しました。`PasswordResetToken#valid?`メソッドがActiveRecordの`valid?`メソッドをオーバーライドしており、Ruby 3.4での引数の扱いの変更により互換性問題が発生していました。

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [x] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [ ] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [ ] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック

### バックエンド
- [x] Controller は50行以内
- [x] Service層にビジネスロジック配置済み
- [x] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [ ] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [ ] ApiResult<T> で型安全なエラーハンドリング実装済み
- [ ] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [x] RuboCop 通過（バックエンド変更時）
- [ ] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [x] **バックエンド**: `PasswordResetToken#valid?`を`valid_token?`にリネーム
- [ ] **フロントエンド**: 変更なし
- [ ] **データベース**: 変更なし
- [ ] **その他**: なし

## 動作確認

- [x] 主要機能の動作確認完了
- [ ] エラーケースの動作確認完了
- [ ] 関連機能の回帰テスト完了

## 関連情報

### 問題の詳細
Render.com本番環境のログより：
```
Error in AuthController#forgot_password: wrong number of arguments (given 1, expected 0)
/opt/render/project/src/backend/app/models/password_reset_token.rb:38:in 'valid?'
```

### 原因
- `PasswordResetToken#valid?`がActiveRecordの`valid?`メソッドをオーバーライド
- ActiveRecordの`valid?`は内部で引数を受け取る仕様
- Ruby 3.4での引数処理の変更により互換性問題が発生

### 修正内容
- `valid?`メソッドを`valid_token?`にリネーム
- ActiveRecordのメソッドとの競合を回避

### 影響範囲
- `valid?`メソッドは他の場所で使用されていないため、影響なし
- パスワードリセット機能が正常に動作するようになる

### ローカル動作確認結果
```
Token generated: c6qJvOv7x5GMgYxy2O6q-YihO5-Br3xMRnx2A9lHvE4
Valid: true
```