### PR TITLE
fix: SMTP domain設定をouchi-no-hatake.comに修正

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     user_name: "resend",
     password: ENV["RESEND_API_KEY"],
-    domain: ENV.fetch("FRONTEND_URL", "your-domain.com"),
+    domain: "ouchi-no-hatake.com",
     address: "smtp.resend.com",
     port: 587,
     authentication: :plain,


### PR DESCRIPTION
## 変更概要
SMTP設定の`domain`パラメータが誤って`FRONTEND_URL`環境変数を参照していたため、Resendの送信元ドメイン`ouchi-no-hatake.com`に修正しました。

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/post_service.rb](backend/app/services/post_service.rb) を確認済み
- [x] [backend/app/serializers/application_serializer.rb](backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [ ] [frontend/src/services/apiClient.ts](frontend/src/services/apiClient.ts) を確認済み
- [ ] [frontend/src/types/api.ts](frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [x] Controller は50行以内
- [x] Service層にビジネスロジック配置済み
- [x] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [ ] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [ ] ApiResult<T> で型安全なエラーハンドリング実装済み
- [ ] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [ ] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [ ] RuboCop 通過（バックエンド変更時）
- [ ] ESLint 通過（フロントエンド変更時）
- [ ] ビルド成功確認済み

## 変更内容

### 主な変更
- [x] **バックエンド**: SMTP domain設定を修正
  - [backend/config/environments/production.rb:93](backend/config/environments/production.rb:93): `domain`を`ENV.fetch("FRONTEND_URL")`から`"ouchi-no-hatake.com"`に変更
- [ ] **フロントエンド**: 変更なし
- [ ] **データベース**: 変更なし
- [ ] **その他**: 変更なし

## 動作確認

- [ ] 主要機能の動作確認完了
- [ ] エラーケースの動作確認完了
- [ ] 関連機能の回帰テスト完了

## 関連情報
**問題**: メールが送信されない

**原因**: SMTP設定の`domain`パラメータにフロントエンドURL（`https://ouchi-no-hatake.vercel.app`）が設定されていた

**解決**: Resendで認証済みの送信元ドメイン `ouchi-no-hatake.com` に変更

**影響**: この修正により、ユーザー登録メール・パスワードリセットメールが正常に送信されるようになります

Closes #311（関連PR）