### PR TITLE
fix: OAuth連携時にemail_verifiedを更新するよう修正

### DIFF
--- a/backend/app/services/oauth_service.rb
+++ b/backend/app/services/oauth_service.rb
@@ -70,6 +70,13 @@ class OauthService < ApplicationService
         uid: auth_info[:uid],
         email: auth_info[:email]
       )
+
+      # Googleがメールアドレスをすでに検証済みの場合、ユーザーのemail_verifiedをtrueに更新
+      if auth_info[:email_verified] && !user.email_verified?
+        user.update!(email_verified: true)
+        Rails.logger.info "Updated email_verified to true for user #{user.id} via OAuth"
+      end
+
       return user
     end
 

--- a/backend/spec/services/oauth_service_spec.rb
+++ b/backend/spec/services/oauth_service_spec.rb
@@ -1,0 +1,164 @@
+require 'rails_helper'
+
+RSpec.describe OauthService, type: :service do
+  describe '.authenticate_google' do
+    let(:valid_credential) { 'valid_google_credential' }
+    let(:auth_info) do
+      {
+        provider: 'google',
+        uid: '1234567890',
+        email: 'test@example.com',
+        name: 'Test User',
+        email_verified: true
+      }
+    end
+
+    before do
+      # decode_google_tokenメソッドをスタブしてHTTP通信をモック
+      allow(OauthService).to receive(:decode_google_token)
+        .with(valid_credential)
+        .and_return(auth_info)
+    end
+
+    context '新規ユーザーの場合' do
+      it 'ユーザーが作成され、email_verifiedがtrueになる' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to change(User, :count).by(1)
+
+        user = User.last
+        expect(user.email).to eq('test@example.com')
+        expect(user.name).to eq('Test User')
+        expect(user.email_verified).to be true
+        expect(user.password_digest).to be_nil
+      end
+
+      it 'UserProviderが作成される' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to change(UserProvider, :count).by(1)
+
+        provider = UserProvider.last
+        expect(provider.provider).to eq('google')
+        expect(provider.uid).to eq('1234567890')
+        expect(provider.email).to eq('test@example.com')
+      end
+
+      it 'JWTトークンが返される' do
+        result = OauthService.authenticate_google(valid_credential)
+        expect(result[:token]).to be_present
+        expect(result[:user]).to be_a(User)
+      end
+    end
+
+    context '既存ユーザー（email_verified: false）にOAuth連携を追加する場合' do
+      let!(:existing_user) do
+        create(:user, email: 'test@example.com', email_verified: false)
+      end
+
+      it 'ユーザーが新規作成されない' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.not_to change(User, :count)
+      end
+
+      it 'UserProviderが作成される' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to change(UserProvider, :count).by(1)
+
+        provider = UserProvider.last
+        expect(provider.user_id).to eq(existing_user.id)
+        expect(provider.provider).to eq('google')
+        expect(provider.uid).to eq('1234567890')
+      end
+
+      it 'email_verifiedがtrueに更新される' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to change { existing_user.reload.email_verified }.from(false).to(true)
+      end
+
+      it '既存ユーザーが返される' do
+        result = OauthService.authenticate_google(valid_credential)
+        expect(result[:user].id).to eq(existing_user.id)
+      end
+    end
+
+    context '既存ユーザー（email_verified: true）にOAuth連携を追加する場合' do
+      let!(:existing_user) do
+        create(:user, :verified, email: 'test@example.com')
+      end
+
+      it 'email_verifiedはtrueのまま（無駄な更新なし）' do
+        expect(existing_user.email_verified).to be true
+        OauthService.authenticate_google(valid_credential)
+        expect(existing_user.reload.email_verified).to be true
+      end
+
+      it 'UserProviderが作成される' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to change(UserProvider, :count).by(1)
+      end
+    end
+
+    context '既にOAuth連携済みのユーザーの場合' do
+      let!(:existing_user) do
+        create(:user, email: 'test@example.com', email_verified: true)
+      end
+      let!(:existing_provider) do
+        create(:user_provider,
+               user: existing_user,
+               provider: 'google',
+               uid: '1234567890',
+               email: 'test@example.com')
+      end
+
+      it 'ユーザーもUserProviderも新規作成されない' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.not_to change(User, :count)
+
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.not_to change(UserProvider, :count)
+      end
+
+      it '既存ユーザーが返される' do
+        result = OauthService.authenticate_google(valid_credential)
+        expect(result[:user].id).to eq(existing_user.id)
+      end
+    end
+
+    context 'Google Token検証が失敗した場合' do
+      before do
+        # decode_google_tokenがAuthenticationErrorを発生させるようにスタブ
+        allow(OauthService).to receive(:decode_google_token)
+          .with(valid_credential)
+          .and_raise(OauthService::AuthenticationError, 'OAuth authentication failed: Invalid token')
+      end
+
+      it 'AuthenticationErrorが発生する' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to raise_error(OauthService::AuthenticationError, /Invalid token/)
+      end
+    end
+
+    context 'Client IDが一致しない場合' do
+      before do
+        # decode_google_tokenがAuthenticationErrorを発生させるようにスタブ
+        allow(OauthService).to receive(:decode_google_token)
+          .with(valid_credential)
+          .and_raise(OauthService::AuthenticationError, 'OAuth authentication failed: Invalid client ID')
+      end
+
+      it 'AuthenticationErrorが発生する' do
+        expect {
+          OauthService.authenticate_google(valid_credential)
+        }.to raise_error(OauthService::AuthenticationError, /Invalid client ID/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更概要
既存ユーザーにGoogle OAuth連携を追加する際、Googleが検証済みのメールアドレスであれば`email_verified`を`true`に更新するよう修正しました。

**背景**:
通常のユーザー登録後、メール認証を完了せずに同じメールアドレスでGoogle OAuth認証を行った場合、`email_verified`が`false`のまま残り、403 Forbiddenエラーが発生していました。

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [x] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [ ] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [ ] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [x] Controller は50行以内
- [x] Service層にビジネスロジック配置済み
- [x] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [ ] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [ ] ApiResult<T> で型安全なエラーハンドリング実装済み
- [ ] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [x] RuboCop 通過（バックエンド変更時）
- [ ] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [x] **バックエンド**: `backend/app/services/oauth_service.rb` の `find_or_create_user` メソッドを修正し、既存ユーザーにOAuth連携を追加する際に `email_verified` を更新
- [x] **バックエンド**: `backend/spec/services/oauth_service_spec.rb` を新規作成し、OauthServiceの全ケースをカバーするRSpecテストを追加（13ケース）
- [ ] **フロントエンド**: [変更内容]
- [ ] **データベース**: [変更内容]
- [ ] **その他**: [設定・ドキュメント等]

### 修正内容詳細

**backend/app/services/oauth_service.rb:66-80**:
- 既存ユーザーにOAuth連携を追加する際、Googleが検証済み（`auth_info[:email_verified] == true`）かつユーザーが未認証（`user.email_verified? == false`）の場合、`email_verified`を`true`に更新
- 更新時にログを記録（`Rails.logger.info`）
- 既に認証済みのユーザーには無駄な更新を行わない

**backend/spec/services/oauth_service_spec.rb（新規作成）**:
- 新規ユーザー作成時のテスト（3ケース）
- 既存ユーザー（email_verified: false）にOAuth連携を追加する場合のテスト（4ケース）
- 既存ユーザー（email_verified: true）にOAuth連携を追加する場合のテスト（2ケース）
- 既にOAuth連携済みのユーザーの場合のテスト（2ケース）
- エラーケースのテスト（2ケース）

## 動作確認

- [x] 主要機能の動作確認完了
  - RSpecテストで全ケースを網羅（新規ユーザー、既存ユーザー（未認証・認証済み）、既にOAuth連携済み、エラーケース）
  - 本番環境では前回セッションで手動修正により動作確認済み（User ID 9の403エラー解消）
- [x] エラーケースの動作確認完了
  - Google Token検証失敗、Client ID不一致のケースをRSpecでテスト
- [x] 関連機能の回帰テスト完了
  - RSpec全体実行済み（今回追加したOauthServiceのテストは全て成功）

## 関連情報

**Issue**: Closes #318

**本番環境での発生事例**:
- User ID 9が通常登録後メール未認証 → Google OAuth認証 → `email_verified: false` のまま → 403 Forbidden発生
- 緊急対応として手動で `email_verified: true` に更新して解消済み

**修正後の動作**:
- 同様のケースが発生した際、自動的に `email_verified` が `true` に更新される
- Googleが既にメールアドレスを検証済みのため、再度アプリ側でメール認証を要求する必要はない