### PR TITLE
fix: OGP画像URLを絶対URLに変更してSNS共有時の表示を修正

### DIFF
--- a/frontend/src/app/checker/layout.tsx
+++ b/frontend/src/app/checker/layout.tsx
@@ -6,11 +6,13 @@ export const metadata: Metadata = {
   openGraph: {
     title: '家庭菜園チェッカー | おうちの畑',
     description: '簡単な質問に答えるだけで、あなたにぴったりの野菜が見つかります。初心者でも育てやすい野菜を診断して、家庭菜園を始めましょう！',
+    url: 'https://ouchi-no-hatake.com/checker',
+    siteName: 'おうちの畑',
     type: 'website',
     locale: 'ja_JP',
     images: [
       {
-        url: '/ogp-checker.png',
+        url: 'https://ouchi-no-hatake.com/ogp-checker.png',
         width: 1200,
         height: 630,
         alt: '家庭菜園チェッカー | おうちの畑',
@@ -21,7 +23,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: '家庭菜園チェッカー | おうちの畑',
     description: '簡単な質問に答えるだけで、あなたにぴったりの野菜が見つかります。初心者でも育てやすい野菜を診断して、家庭菜園を始めましょう！',
-    images: ['/ogp-checker.png'],
+    images: ['https://ouchi-no-hatake.com/ogp-checker.png'],
   },
 }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
     type: 'website',
     images: [
       {
-        url: '/ogp.png',
+        url: 'https://ouchi-no-hatake.com/ogp.png',
         width: 1200,
         height: 630,
         alt: 'おうちの畑 - 家庭菜園を、もっと身近。',
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'おうちの畑',
     description: '初心者が気軽に家庭菜園を始められる掲示板型サービス。野菜診断で育てやすい野菜を提案し、育て方指南で栽培をサポート。成長記録を共有して楽しく野菜を育てよう。',
-    images: ['/ogp.png'],
+    images: ['https://ouchi-no-hatake.com/ogp.png'],
   },
 }
 


### PR DESCRIPTION
## 変更概要
本番環境で家庭菜園チェッカーの結果をX(Twitter)でシェアした際、OGP画像が表示されない問題を修正しました。OGP画像のURLを相対パス（`/ogp-checker.png`）から絶対URL（`https://ouchi-no-hatake.com/ogp-checker.png`）に変更し、SNSクローラーが正しく画像を取得できるようにしました。

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [ ] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [ ] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [x] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [x] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [ ] Controller は50行以内
- [ ] Service層にビジネスロジック配置済み
- [ ] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [ ] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [ ] ApiResult<T> で型安全なエラーハンドリング実装済み
- [ ] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [ ] RuboCop 通過（バックエンド変更時）
- [x] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [ ] **バックエンド**: 該当なし
- [x] **フロントエンド**: OGPメタデータの画像URLを絶対URLに変更
- [ ] **データベース**: 該当なし
- [ ] **その他**: 該当なし

### 修正ファイル
1. **frontend/src/app/checker/layout.tsx**
   - `openGraph.url`: 追加（`https://ouchi-no-hatake.com/checker`）
   - `openGraph.siteName`: 追加（`おうちの畑`）
   - `openGraph.images[0].url`: `/ogp-checker.png` → `https://ouchi-no-hatake.com/ogp-checker.png`
   - `twitter.images[0]`: `/ogp-checker.png` → `https://ouchi-no-hatake.com/ogp-checker.png`

2. **frontend/src/app/layout.tsx**
   - `openGraph.images[0].url`: `/ogp.png` → `https://ouchi-no-hatake.com/ogp.png`
   - `twitter.images[0]`: `/ogp.png` → `https://ouchi-no-hatake.com/ogp.png`

## 動作確認

- [x] 主要機能の動作確認完了（ローカル環境でcurlによるOGPタグ確認）
- [x] エラーケースの動作確認完了（該当なし）
- [x] 関連機能の回帰テスト完了（既存ページのOGP設定に影響なし）

### ローカル検証内容
```bash
# Docker環境起動確認
docker-compose ps

# OGPタグの確認
curl http://localhost:3000/checker | grep "og:image"
# 結果: <meta property="og:image" content="https://ouchi-no-hatake.com/ogp-checker.png"/>

curl http://localhost:3000 | grep "og:image"
# 結果: <meta property="og:image" content="https://ouchi-no-hatake.com/ogp.png"/>
```

## 関連情報

### 問題の背景
- 本番環境で家庭菜園チェッカーの結果をX(Twitter)でシェアした際、OGP画像が表示されない
- Twitter Card Validator: "ERROR: No card found (Card error)"

### 原因
- OGP画像URLが相対パス（`/ogp-checker.png`）だったため、SNSクローラーが画像を取得できなかった
- SNSクローラーはHTML単体を取得し、別途画像をリクエストするため、完全なURLが必要

### 修正内容
- 全OGP画像URLを絶対URL（`https://ouchi-no-hatake.com/ogp-checker.png`）に変更
- `url`と`siteName`フィールドも追加して、OGP設定を完全化

### Next.jsの仕様
- `public/`ディレクトリのファイルは静的ファイルとして公開される
- Next.jsビルド時に`public/`のファイルは出力ディレクトリにコピーされ、HTTPで取得可能
- `metadataBase`を設定していても、子レイアウトの相対パスが必ずしも絶対URLに変換されるわけではない