### PR TITLE
fix: ミドルウェアのRewriteパスを修正（ルートグループを除外）

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -45,7 +45,7 @@ export function middleware(request: NextRequest) {
   // /checkerへのBotアクセスを静的OGPページにRewrite
   if (pathname === '/checker' && BOT_UA.test(ua)) {
     const url = request.nextUrl.clone();
-    url.pathname = '/(ogp)/checker-share';
+    url.pathname = '/checker-share';  // ルートグループ(ogp)はURLに含まれない
     return NextResponse.rewrite(url);
   }
 


### PR DESCRIPTION
## 変更概要
ミドルウェアのRewrite先パスが誤って`/(ogp)/checker-share`となっていましたが、Next.jsのルートグループ`(ogp)`はURLには含まれないため、正しい`/checker-share`に修正しました。

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 変更内容

### 修正箇所
**frontend/src/middleware.ts:48**
```diff
- url.pathname = '/(ogp)/checker-share';
+ url.pathname = '/checker-share';  // ルートグループ(ogp)はURLに含まれない
```

### 問題の原因
- Next.jsのルートグループ（`(ogp)`のように括弧で囲まれたディレクトリ）はファイルシステム上の整理用であり、実際のURLパスには含まれません
- ファイルパス: `app/(ogp)/checker-share/page.tsx`
- 実際のURL: `/checker-share`（`(ogp)`は含まれない）
- ミドルウェアで`/(ogp)/checker-share`にRewriteしようとしたため、404エラーになっていた

### 修正による効果
- SNSクローラーが`/checker`にアクセス → ミドルウェアで検出 → `/checker-share`に正しくRewrite
- 静的OGPページが正常に表示される
- `<head>`内のメタタグをSNSクローラーが読み取れる

## 動作確認
- [x] ビルド成功確認済み
- [x] ミドルウェアロジックの修正のみ（既存機能への影響なし）

## 関連情報
PR #325 の修正。ルートグループの仕様理解不足による初歩的なミス。