### PR TITLE
fix: Bot専用の静的カードでOGPメタデータを直接出力

### DIFF
--- a/frontend/public/card.html
+++ b/frontend/public/card.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <title>おうちの畑 | 共有カード</title>
+
+  <!-- ★ Twitterは name= 属性。最低限これが必須 -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <!-- 任意だが推奨 -->
+  <!-- <meta name="twitter:site" content="@your_account" /> -->
+  <meta name="twitter:title" content="家庭菜園チェッカー | おうちの畑" />
+  <meta name="twitter:description" content="あなたの環境に合う作物を診断できます。" />
+  <meta name="twitter:image" content="https://ouchi-no-hatake.com/ogp.png?v=20251103a" />
+
+  <!-- OGP（併記OK。Xは twitter:* を優先） -->
+  <meta property="og:title" content="家庭菜園チェッカー | おうちの畑" />
+  <meta property="og:description" content="あなたの環境に合う作物を診断できます。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ouchi-no-hatake.com/" />
+  <meta property="og:site_name" content="おうちの畑" />
+  <meta property="og:image" content="https://ouchi-no-hatake.com/ogp.png?v=20251103a" />
+</head>
+<body>
+  <main>
+    <h1>共有カード用ページ</h1>
+    <a href="/">トップへ</a>
+  </main>
+</body>
+</html>

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+// 主要SNSクローラーUA（必要に応じて追加）
+const BOT_UA =
+  /(Twitterbot|facebookexternalhit|Slackbot|Line|Discordbot|Pinterest|LinkedInBot|WhatsApp)/i;
+
 const getTokenFromCookie = (request: NextRequest) => {
   const tokenCookie = request.cookies.get('auth_token');
   return tokenCookie?.value;
@@ -36,7 +40,15 @@ function verifyJWT(token: string): boolean {
 }
 
 export function middleware(request: NextRequest) {
+  const ua = request.headers.get('user-agent') || '';
   const { pathname } = request.nextUrl;
+
+  // ルートのカードを取りたいBotには public/card.html を返す
+  if (pathname === '/' && BOT_UA.test(ua)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/card.html'; // ← public/ 配下の静的HTML
+    return NextResponse.rewrite(url);
+  }
 
   // /dashboard配下のみ認証必須
   if (!pathname.startsWith('/dashboard')) {
@@ -54,5 +66,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*'],
+  matcher: ['/', '/dashboard/:path*'],
 }


### PR DESCRIPTION
## 変更概要

Twitter Card Validatorで「ERROR: No card found (Card error)」が継続発生していた問題を、Bot UA専用の完全静的HTMLで解決しました。

**問題**: Next.js 15のストリーミングメタデータにより、`twitter:card`メタタグが`<head>`に直接出力されず、XのBotが認識できない
**解決**: App Routerを完全にバイパスする静的HTML + middleware Rewrite方式を採用

## 種別
- [x] **Bug**: バグ修正
- [ ] **Feature**: 新機能追加
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [ ] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [ ] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [x] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [x] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [ ] Controller は50行以内
- [ ] Service層にビジネスロジック配置済み
- [ ] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [x] apiClient.post/get/put/delete 使用（直接fetch禁止） - 該当なし（静的HTMLのみ）
- [x] ApiResult<T> で型安全なエラーハンドリング実装済み - 該当なし
- [x] types/ に型定義追加済み - 該当なし
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用 - 該当なし
- [x] console.log は開発環境のみで使用 - 該当なし
- [x] 適切なバリデーション・サニタイゼーション実装済み - 該当なし（静的HTML）
- [x] 認証・認可の適切な実装（該当する場合） - 該当なし（公開カードページ）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [ ] RuboCop 通過（バックエンド変更時）
- [x] ESLint 通過（フロントエンド変更時）
- [x] ビルド成功確認済み

## 変更内容

### 主な変更
- [ ] **バックエンド**: 変更なし
- [x] **フロントエンド**: 
  - `public/card.html` 新規作成（完全静的HTML、`<meta name="twitter:card">`必須タグ含む）
  - `middleware.ts` にBot UA検出とRewriteロジック追加（ルート`/`へのBot UAアクセス時に`/card.html`返却）
- [ ] **データベース**: 変更なし
- [ ] **その他**: なし

## 動作確認

- [x] 主要機能の動作確認完了（ビルド成功、middlewareの既存認証ロジック動作）
- [x] エラーケースの動作確認完了（該当なし）
- [x] 関連機能の回帰テスト完了（middleware認証ロジックは既存通り動作）

## 関連情報

### デプロイ後の検証手順

1. **Bot UAでのHTML確認**:
   ```bash
   curl -s -A "Twitterbot/1.0" https://ouchi-no-hatake.com | head -140
   ```
   期待: `<meta name="twitter:card" content="summary_large_image" />` が`<head>`に直接出力

2. **一般UAでの通常動作**:
   ```bash
   curl -s https://ouchi-no-hatake.com | head -100
   ```
   期待: 通常のNext.jsページ

3. **X Card Validator**: https://ouchi-no-hatake.com でテスト

### 参考資料
- ChatGPT技術提案（Bot専用静的HTML + Rewrite方式）
- 調査記録: [docs/internal/claude-code/sessions/2025-11-03_ogp-metadata-investigation.md](../docs/internal/claude-code/sessions/2025-11-03_ogp-metadata-investigation.md)
- 過去の試行（全て失敗）: PR #323, #324, #325, #326, #327
- 今回の違い: App Routerを完全にバイパス（グローバルレイアウト、GAの影響なし）