### PR TITLE
fix: 本番環境でActive Storage画像のS3直接URLを返すように修正

### DIFF
--- a/backend/app/services/auth_service.rb
+++ b/backend/app/services/auth_service.rb
@@ -282,7 +282,8 @@ class AuthService < ApplicationService
       if Rails.env.development?
         Rails.application.routes.url_helpers.rails_blob_url(user.avatar, host: "http://localhost:3001")
       else
-        Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true)
+        # 本番環境ではS3の直接URLを返す
+        user.avatar.url
       end
     else
       nil

--- a/backend/app/services/growth_record_service.rb
+++ b/backend/app/services/growth_record_service.rb
@@ -438,7 +438,8 @@ class GrowthRecordService < ApplicationService
       if Rails.env.development?
         Rails.application.routes.url_helpers.rails_blob_url(record.thumbnail, host: "http://localhost:3001")
       else
-        Rails.application.routes.url_helpers.rails_blob_path(record.thumbnail, only_path: true)
+        # 本番環境ではS3の直接URLを返す
+        record.thumbnail.url
       end
     else
       nil

--- a/backend/app/services/post_service.rb
+++ b/backend/app/services/post_service.rb
@@ -129,7 +129,14 @@ class PostService < ApplicationService
   # 画像URL生成（プライベートメソッド）
   def self.build_image_urls(post)
     if post.images.attached?
-      post.images.map { |image| Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) }
+      post.images.map do |image|
+        if Rails.env.development?
+          Rails.application.routes.url_helpers.rails_blob_url(image, host: "http://localhost:3001")
+        else
+          # 本番環境ではS3の直接URLを返す
+          image.url
+        end
+      end
     else
       []
     end

--- a/backend/app/services/user_service.rb
+++ b/backend/app/services/user_service.rb
@@ -71,7 +71,8 @@ class UserService < ApplicationService
     if Rails.env.development?
       Rails.application.routes.url_helpers.rails_blob_url(user.avatar, host: "http://localhost:3001")
     else
-      Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true)
+      # 本番環境ではS3の直接URLを返す
+      user.avatar.url
     end
   end
   private_class_method :build_avatar_url

--- a/frontend/src/app/posts/[id]/page.tsx
+++ b/frontend/src/app/posts/[id]/page.tsx
@@ -148,7 +148,9 @@ export default function PostDetailPage() {
   // 画像クリック処理
   const handleImageClick = (imageIndex: number) => {
     if (post?.images && post.images.length > 0) {
-      const fullImageUrls = post.images.map(imageUrl => `${API_BASE_URL}${imageUrl}`)
+      const fullImageUrls = post.images.map(imageUrl =>
+        imageUrl.startsWith('http') ? imageUrl : `${API_BASE_URL}${imageUrl}`
+      )
       openModal(fullImageUrls, imageIndex, post.title || `${post.user.name}の投稿`)
     }
   }
@@ -527,7 +529,7 @@ export default function PostDetailPage() {
               {post.images.map((imageUrl, index) => (
                 <div key={index} className="relative cursor-pointer">
                   <img
-                    src={`${API_BASE_URL}${imageUrl}`}
+                    src={imageUrl.startsWith('http') ? imageUrl : `${API_BASE_URL}${imageUrl}`}
                     alt={`投稿画像 ${index + 1}`}
                     className={`w-full rounded-md border border-gray-200 transition-opacity hover:opacity-90 ${
                       post.images?.length === 1

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -63,7 +63,9 @@ export default function TimelinePost({ post }: TimelinePostProps) {
 
   const handleImageClick = (imageIndex: number) => {
     if (post.images && post.images.length > 0) {
-      const fullImageUrls = post.images.map(imageUrl => `${API_BASE_URL}${imageUrl}`)
+      const fullImageUrls = post.images.map(imageUrl =>
+        imageUrl.startsWith('http') ? imageUrl : `${API_BASE_URL}${imageUrl}`
+      )
       openModal(fullImageUrls, imageIndex, post.title || `${post.user.name}の投稿`)
     }
   }
@@ -261,11 +263,11 @@ export default function TimelinePost({ post }: TimelinePostProps) {
             {post.images.map((imageUrl, index) => (
               <div key={index} className="relative cursor-pointer">
                 <img
-                  src={`${API_BASE_URL}${imageUrl}`}
+                  src={imageUrl.startsWith('http') ? imageUrl : `${API_BASE_URL}${imageUrl}`}
                   alt={`投稿画像 ${index + 1}`}
                   className={`w-full rounded-md border border-gray-200 transition-opacity hover:opacity-90 ${
-                    post.images?.length === 1 
-                      ? 'max-h-80 object-contain' 
+                    post.images?.length === 1
+                      ? 'max-h-80 object-contain'
                       : 'h-36 object-cover'
                   }`}
                   onClick={() => handleImageClick(index)}


### PR DESCRIPTION
## 変更概要
本番環境で成長記録のサムネイル、ユーザーアバター、投稿画像が404エラーで表示されない問題を修正しました。

**問題の原因:**
- バックエンドが相対パス(`/rails/active_storage/...`)を返していた
- フロントエンド(`ouchi-no-hatake.com`)とバックエンド(`api.ouchi-no-hatake.com`)が異なるドメインのため、相対パスが正しく解決されず404エラーが発生
- フロントエンドが絶対URLに対しても常に`API_BASE_URL`を追加していた

**解決策:**
- 本番環境ではS3の直接URLを返すように変更
- フロントエンドで絶対URL判定を追加し、httpで始まる場合は`API_BASE_URL`を追加しないように修正
- 開発環境の動作は変更なし

## 種別
- [ ] **Feature**: 新機能追加
- [x] **Bug**: バグ修正
- [ ] **Refactor**: リファクタリング・コード改善
- [ ] **Security**: セキュリティ問題修正
- [ ] **Docs**: ドキュメント更新
- [ ] **Chore**: ビルド・設定変更

## 実装前チェック（確認済み）
> **重要**: 以下を実装前に確認したことを示してください

### 参考コード確認
**バックエンド実装時**:
- [x] [backend/app/services/post_service.rb](../backend/app/services/post_service.rb) を確認済み
- [x] [backend/app/serializers/application_serializer.rb](../backend/app/serializers/application_serializer.rb) を確認済み

**フロントエンド実装時**:
- [x] [frontend/src/services/apiClient.ts](../frontend/src/services/apiClient.ts) を確認済み
- [x] [frontend/src/types/api.ts](../frontend/src/types/api.ts) を確認済み

### ブランチ確認
- [x] `git branch` で適切なブランチを確認済み（mainではない）

---

## 実装パターン準拠チェック
> **重要**: リファクタ成果を維持するため、以下を確認してください

### バックエンド
- [x] Controller は50行以内
- [x] Service層にビジネスロジック配置済み
- [x] ApplicationSerializer でレスポンス統一済み
```ruby
# 正しいパターン例
def create
  result = Service.create_resource(current_user, params)
  render json: ApplicationSerializer.success(result), status: :created
end
```

### フロントエンド
- [x] apiClient.post/get/put/delete 使用（直接fetch禁止）
- [x] ApiResult<T> で型安全なエラーハンドリング実装済み
- [x] types/ に型定義追加済み
```typescript
// 正しいパターン例
const result = await apiClient.post<ResponseType>('/api/v1/endpoint', data)
if (result.success) {
  // result.data は型安全
} else {
  // result.error.message
}
```

---

## セキュリティチェック
> **重要**: セキュリティ要件を満たしていることを確認してください

- [x] 機密情報（JWT、パスワード、個人情報）のログ出力なし
- [x] Logger.debug() または環境分岐使用
- [x] console.log は開発環境のみで使用
- [x] 適切なバリデーション・サニタイゼーション実装済み
- [x] 認証・認可の適切な実装（該当する場合）

---

## 品質チェック
> **重要**: コード品質基準を満たしていることを確認してください

### コードメトリクス
- [x] メソッド50行以内
- [x] クラス/コンポーネント200行以内
- [x] 単一責任原則の遵守

### ビルド・品質ツール
- [ ] RuboCop 通過（バックエンド変更時）
- [ ] ESLint 通過（フロントエンド変更時）
- [ ] ビルド成功確認済み

## 変更内容

### 主な変更
- [x] **バックエンド**: 本番環境でS3直接URLを返すようにService層を修正（4ファイル）
- [x] **フロントエンド**: 絶対URL判定を追加してURL処理を修正（2ファイル）
- [ ] **データベース**: [変更内容]
- [ ] **その他**: [設定・ドキュメント等]

## 動作確認

- [x] 主要機能の動作確認完了
- [x] エラーケースの動作確認完了
- [x] 関連機能の回帰テスト完了

## 関連情報

**修正ファイル:**

Backend:
- backend/app/services/growth_record_service.rb - サムネイルURL生成
- backend/app/services/user_service.rb - アバターURL生成
- backend/app/services/auth_service.rb - 認証時のアバターURL生成
- backend/app/services/post_service.rb - 投稿画像URL生成

Frontend:
- frontend/src/components/timeline/TimelinePost.tsx - タイムライン投稿画像表示
- frontend/src/app/posts/[id]/page.tsx - 投稿詳細画像表示

**動作確認済み:**
- 成長記録のサムネイル画像表示
- 成長メモの投稿画像表示
- 雑談投稿の画像表示
- マイページのアイコン表示

Closes #[issue番号]
